### PR TITLE
Add capnp converters to and from YAML and JSON.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Get and build tools
       run: |
         make env
-        git clone -b metadata_annotations https://github.com/litghost/RapidWright.git $GITHUB_WORKSPACE/env/RapidWright
+        git clone -b interchange https://github.com/Xilinx/RapidWright.git $GITHUB_WORKSPACE/env/RapidWright
         make -C "$GITHUB_WORKSPACE/env/RapidWright" update_jars
         git clone https://github.com/capnproto/capnproto-java.git $GITHUB_WORKSPACE/env/capnproto-java
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Get and build tools
       run: |
         make env
-        git clone -b interchange https://github.com/Xilinx/RapidWright.git $GITHUB_WORKSPACE/env/RapidWright
+        git clone -b metadata_annotations https://github.com/litghost/RapidWright.git $GITHUB_WORKSPACE/env/RapidWright
         make -C "$GITHUB_WORKSPACE/env/RapidWright" update_jars
         git clone https://github.com/capnproto/capnproto-java.git $GITHUB_WORKSPACE/env/capnproto-java
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
 
     - name: Install
       run: |
+        sudo apt-get install libyaml-dev libyaml-cpp-dev
         pip install --upgrade -r requirements.txt
 
     - name: Check formatting

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -14,4 +14,8 @@ export INTERCHANGE_SCHEMA_PATH="$GITHUB_WORKSPACE/env/RapidWright/interchange"
 export DEVICE_RESOURCE_PATH="$GITHUB_WORKSPACE/env"
 
 make test-py
+RESULT=$?
+if [ $RESULT -ne 0 ]; then
+    exit $RESULT
+fi
 test $(git status --porcelain | wc -l) -eq 0 || { git diff; false; }

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ src
 dist
 env
 *.swp
+*.swo
+*.yaml

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ format: ${PYTHON_SRCS}
 	$(IN_ENV) yapf -i ${PYTHON_SRCS}
 
 test-py:
-	$(IN_ENV) pytest --doctest-modules
+	$(IN_ENV) pytest -s --doctest-modules
 
 clean:
 	rm -rf env

--- a/fpga_interchange/annotations.py
+++ b/fpga_interchange/annotations.py
@@ -1,0 +1,78 @@
+from fpga_interchange.capnp_utils import get_module_from_id
+
+def get_first_enum_field_display_name(annotation_value, parser=None):
+    field0_proto = annotation_value.schema.fields_list[0].proto
+    if field0_proto.which() != 'slot':
+        return None
+
+    field0_type = field0_proto.slot.type
+    if field0_type.which() != 'enum':
+        return None
+
+    e = get_module_from_id(field0_type.enum.typeId, parser)
+    return e.schema.node.displayName
+
+def get_annotation_value(annotation, parser=None):
+    """ Get annotation value from an annotation.  Schema that the annotation belongs too is required. """
+
+    annotation_module = get_module_from_id(annotation.id, parser)
+    name = annotation_module.__name__
+
+    which = annotation.value.which()
+    if which == 'struct':
+        annotation_type = annotation_module._nodeSchema.node.annotation.type
+
+        assert annotation_type.which() == 'struct'
+        struct_type_id = annotation_type.struct.typeId
+        annotation_struct_type = get_module_from_id(struct_type_id, parser)
+
+        return name, annotation.value.struct.as_struct(annotation_struct_type)
+    elif which == 'void':
+        return name, None
+    elif which in [
+        'bool',
+        'float32',
+        'float64',
+        'int16',
+        'int32',
+        'int64',
+        'int8',
+        'text',
+        'uint16',
+        'uint32',
+        'uint64',
+        'uint8']:
+        return name, getattr(annotation.value, which)
+    else:
+        raise NotImplementedError('Annotation of type {} not supported yet.'.format(which))
+
+
+class AnnotationCache():
+    def __init__(self, parser=None):
+        self.parser = parser
+
+        self.annotation_values = {}
+        self.annotation_display_names = {}
+
+    def get_annotation_value(self, annotation):
+        if annotation.id not in self.annotation_values:
+            self.annotation_values[annotation.id] = get_annotation_value(annotation, self.parser)
+
+        return self.annotation_values[annotation.id]
+
+    def is_first_field_display_name(self, annotation, expected_display_name):
+        if annotation.id not in self.annotation_display_names:
+            _, annotation_value = self.get_annotation_value(annotation)
+            self.annotation_display_names[annotation.id] = get_first_enum_field_display_name(annotation_value, self.parser)
+
+        display_name = self.annotation_display_names[annotation.id]
+        if display_name is None:
+            return False
+        return display_name == expected_display_name
+
+    def is_reference_annotation(self, annotation):
+        return self.is_first_field_display_name(annotation, 'References.capnp:ReferenceType')
+
+
+    def is_implementation_annotation(self, annotation):
+        return self.is_first_field_display_name(annotation, 'References.capnp:ImplementationType')

--- a/fpga_interchange/annotations.py
+++ b/fpga_interchange/annotations.py
@@ -37,7 +37,6 @@ def get_annotation_value(annotation, parser=None):
         assert annotation_type.which() == 'struct'
         struct_type_id = annotation_type.struct.typeId
         annotation_struct_type = get_module_from_id(struct_type_id, parser)
-
         return name, annotation.value.struct.as_struct(annotation_struct_type)
     elif which == 'void':
         return name, None
@@ -58,16 +57,17 @@ class AnnotationCache():
         self.annotation_values = {}
         self.annotation_display_names = {}
 
-    def get_annotation_value(self, annotation):
-        if annotation.id not in self.annotation_values:
-            self.annotation_values[annotation.id] = get_annotation_value(
+    def get_annotation_value(self, node_id, field_idx, annotation_idx, annotation):
+        key = (node_id, field_idx, annotation_idx)
+        if key not in self.annotation_values:
+            self.annotation_values[key] = get_annotation_value(
                 annotation, self.parser)
 
-        return self.annotation_values[annotation.id]
+        return self.annotation_values[key]
 
     def is_first_field_display_name(self, annotation, expected_display_name):
         if annotation.id not in self.annotation_display_names:
-            _, annotation_value = self.get_annotation_value(annotation)
+            _, annotation_value = get_annotation_value(annotation, self.parser)
             self.annotation_display_names[
                 annotation.id] = get_first_enum_field_display_name(
                     annotation_value, self.parser)

--- a/fpga_interchange/annotations.py
+++ b/fpga_interchange/annotations.py
@@ -1,3 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
 from fpga_interchange.capnp_utils import get_module_from_id
 
 

--- a/fpga_interchange/annotations.py
+++ b/fpga_interchange/annotations.py
@@ -57,7 +57,8 @@ class AnnotationCache():
         self.annotation_values = {}
         self.annotation_display_names = {}
 
-    def get_annotation_value(self, node_id, field_idx, annotation_idx, annotation):
+    def get_annotation_value(self, node_id, field_idx, annotation_idx,
+                             annotation):
         key = (node_id, field_idx, annotation_idx)
         if key not in self.annotation_values:
             self.annotation_values[key] = get_annotation_value(

--- a/fpga_interchange/annotations.py
+++ b/fpga_interchange/annotations.py
@@ -8,10 +8,32 @@
 # https://opensource.org/licenses/ISC
 #
 # SPDX-License-Identifier: ISC
+""" Defines some utility functions for inspecting capnp annotations.
+
+get_annotation_value is generic to any capnp file.
+
+get_first_enum_field_display_name and AnnotationCache are both specific
+to the annotations used in the FPGA interchange capnp format.
+
+"""
 from fpga_interchange.capnp_utils import get_module_from_id
 
 
 def get_first_enum_field_display_name(annotation_value, parser=None):
+    """ Returns the displayName of annotations of a specific structure.
+
+    All annotations used for FPGA interchange capnp file annotations have
+    an enum as the first field.  This functions returns the displayName of the
+    supplied annotation_value, if and only if the first field of the
+    annotation_value is an enum.
+
+    The parser argument is optional, as the default parser is the global
+    parser defined by pycapnp.  In the event that the annotation in question
+    was not parsed by this parser, that parser should be supplied.
+    This case should be rare.
+
+    """
+
     field0_proto = annotation_value.schema.fields_list[0].proto
     if field0_proto.which() != 'slot':
         return None
@@ -51,6 +73,23 @@ def get_annotation_value(annotation, parser=None):
 
 
 class AnnotationCache():
+    """ Cache for annotation values and display names.
+
+    Because parsing annotation values requires non-trival operations to
+    inspect, it is useful to provide a simple cache of annotations based on a
+    structural key.
+
+    In this case the structural key is:
+     - node_id - The unique id supplied to the capnp struct the annotation
+                 comes from.
+     - field_idx - The field number that the annotation applies too.
+     - annotation_idx - The index into the annotations list.
+
+    It is believed that the above 3-tuple uniquely specifies an annotation in
+    a schema.
+
+    """
+
     def __init__(self, parser=None):
         self.parser = parser
 
@@ -59,6 +98,7 @@ class AnnotationCache():
 
     def get_annotation_value(self, node_id, field_idx, annotation_idx,
                              annotation):
+        """ Get the annotation value for the specified annotation at the specified key. """
         key = (node_id, field_idx, annotation_idx)
         if key not in self.annotation_values:
             self.annotation_values[key] = get_annotation_value(
@@ -67,6 +107,7 @@ class AnnotationCache():
         return self.annotation_values[key]
 
     def is_first_field_display_name(self, annotation, expected_display_name):
+        """ See if the annotation displayName supplied matches the expected_display_name. """
         if annotation.id not in self.annotation_display_names:
             _, annotation_value = get_annotation_value(annotation, self.parser)
             self.annotation_display_names[
@@ -79,9 +120,11 @@ class AnnotationCache():
         return display_name == expected_display_name
 
     def is_reference_annotation(self, annotation):
+        """ Is the annotation a FPGA interchange text reference annotation? """
         return self.is_first_field_display_name(
             annotation, 'References.capnp:ReferenceType')
 
     def is_implementation_annotation(self, annotation):
+        """ Is the annotation a FPGA interchange text impl annotation? """
         return self.is_first_field_display_name(
             annotation, 'References.capnp:ImplementationType')

--- a/fpga_interchange/annotations.py
+++ b/fpga_interchange/annotations.py
@@ -1,5 +1,6 @@
 from fpga_interchange.capnp_utils import get_module_from_id
 
+
 def get_first_enum_field_display_name(annotation_value, parser=None):
     field0_proto = annotation_value.schema.fields_list[0].proto
     if field0_proto.which() != 'slot':
@@ -11,6 +12,7 @@ def get_first_enum_field_display_name(annotation_value, parser=None):
 
     e = get_module_from_id(field0_type.enum.typeId, parser)
     return e.schema.node.displayName
+
 
 def get_annotation_value(annotation, parser=None):
     """ Get annotation value from an annotation.  Schema that the annotation belongs too is required. """
@@ -30,21 +32,13 @@ def get_annotation_value(annotation, parser=None):
     elif which == 'void':
         return name, None
     elif which in [
-        'bool',
-        'float32',
-        'float64',
-        'int16',
-        'int32',
-        'int64',
-        'int8',
-        'text',
-        'uint16',
-        'uint32',
-        'uint64',
-        'uint8']:
+            'bool', 'float32', 'float64', 'int16', 'int32', 'int64', 'int8',
+            'text', 'uint16', 'uint32', 'uint64', 'uint8'
+    ]:
         return name, getattr(annotation.value, which)
     else:
-        raise NotImplementedError('Annotation of type {} not supported yet.'.format(which))
+        raise NotImplementedError(
+            'Annotation of type {} not supported yet.'.format(which))
 
 
 class AnnotationCache():
@@ -56,14 +50,17 @@ class AnnotationCache():
 
     def get_annotation_value(self, annotation):
         if annotation.id not in self.annotation_values:
-            self.annotation_values[annotation.id] = get_annotation_value(annotation, self.parser)
+            self.annotation_values[annotation.id] = get_annotation_value(
+                annotation, self.parser)
 
         return self.annotation_values[annotation.id]
 
     def is_first_field_display_name(self, annotation, expected_display_name):
         if annotation.id not in self.annotation_display_names:
             _, annotation_value = self.get_annotation_value(annotation)
-            self.annotation_display_names[annotation.id] = get_first_enum_field_display_name(annotation_value, self.parser)
+            self.annotation_display_names[
+                annotation.id] = get_first_enum_field_display_name(
+                    annotation_value, self.parser)
 
         display_name = self.annotation_display_names[annotation.id]
         if display_name is None:
@@ -71,8 +68,9 @@ class AnnotationCache():
         return display_name == expected_display_name
 
     def is_reference_annotation(self, annotation):
-        return self.is_first_field_display_name(annotation, 'References.capnp:ReferenceType')
-
+        return self.is_first_field_display_name(
+            annotation, 'References.capnp:ReferenceType')
 
     def is_implementation_annotation(self, annotation):
-        return self.is_first_field_display_name(annotation, 'References.capnp:ImplementationType')
+        return self.is_first_field_display_name(
+            annotation, 'References.capnp:ImplementationType')

--- a/fpga_interchange/capnp_utils.py
+++ b/fpga_interchange/capnp_utils.py
@@ -1,5 +1,6 @@
 import capnp.lib.capnp
 
+
 def get_module_from_id(capnp_id, parser=None):
     if parser is None:
         parser = capnp.lib.capnp._global_schema_parser

--- a/fpga_interchange/capnp_utils.py
+++ b/fpga_interchange/capnp_utils.py
@@ -1,0 +1,7 @@
+import capnp.lib.capnp
+
+def get_module_from_id(capnp_id, parser=None):
+    if parser is None:
+        parser = capnp.lib.capnp._global_schema_parser
+
+    return parser.modules_by_id[capnp_id]

--- a/fpga_interchange/capnp_utils.py
+++ b/fpga_interchange/capnp_utils.py
@@ -1,3 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
 import capnp.lib.capnp
 
 

--- a/fpga_interchange/capnp_utils.py
+++ b/fpga_interchange/capnp_utils.py
@@ -12,6 +12,15 @@ import capnp.lib.capnp
 
 
 def get_module_from_id(capnp_id, parser=None):
+    """ Return the capnp module based on the capnp node id.
+
+    This is useful to determine the schema of a node within a capnp tree.
+
+    The parser argument is optional, as in most circumstances the pycapnp
+    _global_schema_parser is used.  In the event that this parser was not used,
+    the parser must be provide.  This case should be rare.
+
+    """
     if parser is None:
         parser = capnp.lib.capnp._global_schema_parser
 

--- a/fpga_interchange/compare.py
+++ b/fpga_interchange/compare.py
@@ -1,0 +1,131 @@
+#/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+from fpga_interchange.annotations import AnnotationCache
+from fpga_interchange.field_cache import FieldCache, SCALAR_TYPES
+
+
+class CompareCapnp():
+    def __init__(self, unittest, root1, root2):
+        self.annotation_cache = AnnotationCache()
+        self.unittest = unittest
+        self.root1 = root1
+        self.root2 = root2
+        self.field_cache = {}
+        self.value_cache1 = {}
+        self.value_cache2 = {}
+
+    def get_field_cache(self, schema, schema_node_id):
+        if schema_node_id not in self.field_cache:
+            self.field_cache[schema_node_id] = FieldCache(self.annotation_cache, schema)
+        return self.field_cache[schema_node_id]
+
+    def dereference_value(self, annotation, value1, value2):
+        if annotation is None:
+            return value1, value2
+
+        if annotation.type != 'rootValue':
+            return value1, value2
+
+        field = annotation.field
+        if field not in self.value_cache1:
+            self.value_cache1[field] = [v for v in getattr(self.root1, field)]
+            self.value_cache2[field] = [v for v in getattr(self.root2, field)]
+
+        value1 = self.value_cache1[field][value1]
+        value2 = self.value_cache2[field][value2]
+
+        return value1, value2
+
+    def compare_capnp(self, schema_node_id, message1, message2, field_lists=[]):
+        field_cache = self.get_field_cache(message1.schema, schema_node_id)
+
+        fields1 = field_cache.fields(message1)
+        fields2 = field_cache.fields(message2)
+
+        self.unittest.assertEqual(fields1, fields2, msg=str(field_lists))
+
+        orig_field_lists = field_lists
+
+        for field_idx, field in enumerate(field_cache.fields_list):
+            key = field.key
+            if key not in fields1:
+                continue
+
+            field_lists = list(orig_field_lists)
+            field_lists.append(key)
+
+            which = field.which
+            if which == 'group':
+                group1 = getattr(message1, key)
+                group2 = getattr(message2, key)
+
+                inner_key1 = group1.which()
+                inner_key2 = group1.which()
+                self.unittest.assertEqual(inner_key1, inner_key2, msg=str(field_lists))
+
+                field_lists.append(inner_key1)
+                value1 = getattr(group1, inner_key1)
+                value2 = getattr(group2, inner_key2)
+
+                field_proto_data = field.get_group_proto(inner_key1)
+            else:
+                assert which == 'slot', which
+                value1 = getattr(message1, key)
+                value2 = getattr(message2, key)
+
+                field_proto_data = field.get_field_proto()
+
+            if field_proto_data.hide_field:
+                continue
+
+            field_which = field_proto_data.field_which
+            if field_which == 'struct':
+                self.compare_capnp(
+                    schema_node_id=field_proto_data.schema_node_id,
+                    message1=value1,
+                    message2=value2,
+                    field_lists=field_lists)
+            elif field_which == 'list':
+                list_which = field_proto_data.list_which
+
+                field_lists.append(0)
+
+                if list_which == 'struct':
+                    for idx, (elem1, elem2) in enumerate(zip(value1, value2)):
+                        field_lists[-1] = idx
+                        self.compare_capnp(
+                            schema_node_id=field_proto_data.schema_node_id,
+                            message1=elem1,
+                            message2=elem2,
+                            field_lists=field_lists)
+                else:
+                    for idx, (elem1, elem2) in enumerate(zip(value1, value2)):
+                        field_lists[-1] = idx
+                        elem1, elem2 = self.dereference_value(field_proto_data.ref_annotation, elem1, elem2)
+                        self.unittest.assertEqual(elem1, elem2, msg=str(field_lists))
+            elif field_which == 'void':
+                pass
+            elif field_which == 'enum':
+                self.unittest.assertEqual(value1, value2, msg=str(field_lists))
+            else:
+                assert field_which in SCALAR_TYPES, field_which
+
+                value1, value2 = self.dereference_value(field_proto_data.ref_annotation, value1, value2)
+                self.unittest.assertEqual(value1, value2, msg=str(field_lists))
+
+
+def compare_capnp(unittest, message1, message2):
+    schema_node_id = message1.schema.node.id
+
+    unittest.assertEqual(schema_node_id, message2.schema.node.id)
+
+    comp = CompareCapnp(unittest, message1, message2)
+    comp.compare_capnp(schema_node_id, message1, message2)

--- a/fpga_interchange/compare.py
+++ b/fpga_interchange/compare.py
@@ -24,7 +24,8 @@ class CompareCapnp():
 
     def get_field_cache(self, schema, schema_node_id):
         if schema_node_id not in self.field_cache:
-            self.field_cache[schema_node_id] = FieldCache(self.annotation_cache, schema)
+            self.field_cache[schema_node_id] = FieldCache(
+                self.annotation_cache, schema)
         return self.field_cache[schema_node_id]
 
     def dereference_value(self, annotation, value1, value2):
@@ -44,7 +45,8 @@ class CompareCapnp():
 
         return value1, value2
 
-    def compare_capnp(self, schema_node_id, message1, message2, field_lists=[]):
+    def compare_capnp(self, schema_node_id, message1, message2,
+                      field_lists=[]):
         field_cache = self.get_field_cache(message1.schema, schema_node_id)
 
         fields1 = field_cache.fields(message1)
@@ -69,7 +71,8 @@ class CompareCapnp():
 
                 inner_key1 = group1.which()
                 inner_key2 = group1.which()
-                self.unittest.assertEqual(inner_key1, inner_key2, msg=str(field_lists))
+                self.unittest.assertEqual(
+                    inner_key1, inner_key2, msg=str(field_lists))
 
                 field_lists.append(inner_key1)
                 value1 = getattr(group1, inner_key1)
@@ -109,8 +112,10 @@ class CompareCapnp():
                 else:
                     for idx, (elem1, elem2) in enumerate(zip(value1, value2)):
                         field_lists[-1] = idx
-                        elem1, elem2 = self.dereference_value(field_proto_data.ref_annotation, elem1, elem2)
-                        self.unittest.assertEqual(elem1, elem2, msg=str(field_lists))
+                        elem1, elem2 = self.dereference_value(
+                            field_proto_data.ref_annotation, elem1, elem2)
+                        self.unittest.assertEqual(
+                            elem1, elem2, msg=str(field_lists))
             elif field_which == 'void':
                 pass
             elif field_which == 'enum':
@@ -118,7 +123,8 @@ class CompareCapnp():
             else:
                 assert field_which in SCALAR_TYPES, field_which
 
-                value1, value2 = self.dereference_value(field_proto_data.ref_annotation, value1, value2)
+                value1, value2 = self.dereference_value(
+                    field_proto_data.ref_annotation, value1, value2)
                 self.unittest.assertEqual(value1, value2, msg=str(field_lists))
 
 

--- a/fpga_interchange/convert.py
+++ b/fpga_interchange/convert.py
@@ -8,6 +8,7 @@ import fpga_interchange.converters
 SCHEMAS = ('device', 'logical', 'physical')
 FORMATS = ('json', 'yaml', 'capnp')
 
+
 def main():
     parser = argparse.ArgumentParser()
 
@@ -20,14 +21,13 @@ def main():
 
     args = parser.parse_args()
 
-
     schemas = Interchange(args.schema_dir)
 
     schema_map = {
-            'device': schemas.device_resources_schema.Device,
-            'logical': schemas.logical_netlist_schema.Netlist,
-            'physical': schemas.physical_netlist_schema.PhysNetlist,
-            }
+        'device': schemas.device_resources_schema.Device,
+        'logical': schemas.logical_netlist_schema.Netlist,
+        'physical': schemas.physical_netlist_schema.PhysNetlist,
+    }
 
     for schema_str in SCHEMAS:
         assert schema_str in schema_map
@@ -67,6 +67,7 @@ def main():
             f.write(yaml_string)
     else:
         assert False, 'Invalid output format {}'.format(args.output_format)
+
 
 if __name__ == "__main__":
     main()

--- a/fpga_interchange/convert.py
+++ b/fpga_interchange/convert.py
@@ -1,3 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
 import argparse
 import yaml
 from yaml import CSafeLoader as SafeLoader, CDumper as Dumper

--- a/fpga_interchange/convert.py
+++ b/fpga_interchange/convert.py
@@ -48,6 +48,7 @@ def main():
     if args.input_format == 'capnp':
         with open(args.input, 'rb') as f:
             message = read_capnp_file(schema, f)
+            message = message.as_builder()
     elif args.input_format == 'json':
         with open(args.input, 'r') as f:
             json_data = json.load(f)
@@ -68,10 +69,12 @@ def main():
         with open(args.output, 'wb') as f:
             write_capnp_file(message, f)
     elif args.output_format == 'json':
+        message = message.as_reader()
         json_data = to_json(message)
         with open(args.output, 'w') as f:
             json.dump(json_data, f)
     elif args.output_format == 'yaml':
+        message = message.as_reader()
         strings, yaml_tree = to_rapidyaml(message)
         yaml_string = ryml.emit(yaml_tree)
         with open(args.output, 'w') as f:

--- a/fpga_interchange/convert.py
+++ b/fpga_interchange/convert.py
@@ -26,7 +26,7 @@ def main():
     schema_map = {
             'device': schemas.device_resources_schema.Device,
             'logical': schemas.logical_netlist_schema.Netlist,
-            'physical': schemas.logical_netlist_schema.PhysNetlist,
+            'physical': schemas.physical_netlist_schema.PhysNetlist,
             }
 
     for schema_str in SCHEMAS:
@@ -56,11 +56,11 @@ def main():
     if args.output_format == 'capnp':
         with open(args.output, 'wb') as f:
             write_capnp_file(message, f)
-    elif args.input_format == 'json':
+    elif args.output_format == 'json':
         json_data = fpga_interchange.converters.to_yaml(message)
         with open(args.output, 'w') as f:
             json.dump(json_data, f)
-    elif args.input_format == 'yaml':
+    elif args.output_format == 'yaml':
         yaml_data = fpga_interchange.converters.to_yaml(message)
         yaml_string = yaml.dump(yaml_data, Dumper=Dumper)
         with open(args.output, 'w') as f:

--- a/fpga_interchange/convert.py
+++ b/fpga_interchange/convert.py
@@ -1,0 +1,72 @@
+import argparse
+import yaml
+from yaml import CSafeLoader as SafeLoader, CDumper as Dumper
+import json
+from fpga_interchange.interchange_capnp import Interchange, read_capnp_file, write_capnp_file
+import fpga_interchange.converters
+
+SCHEMAS = ('device', 'logical', 'physical')
+FORMATS = ('json', 'yaml', 'capnp')
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--schema_dir', required=True)
+    parser.add_argument('--schema', required=True, choices=SCHEMAS)
+    parser.add_argument('--input_format', required=True, choices=FORMATS)
+    parser.add_argument('--output_format', required=True, choices=FORMATS)
+    parser.add_argument('input')
+    parser.add_argument('output')
+
+    args = parser.parse_args()
+
+
+    schemas = Interchange(args.schema_dir)
+
+    schema_map = {
+            'device': schemas.device_resources_schema.Device,
+            'logical': schemas.logical_netlist_schema.Netlist,
+            'physical': schemas.logical_netlist_schema.PhysNetlist,
+            }
+
+    for schema_str in SCHEMAS:
+        assert schema_str in schema_map
+
+    schema = schema_map[args.schema]
+
+    if args.input_format == 'capnp':
+        with open(args.input, 'rb') as f:
+            message = read_capnp_file(schema, f)
+    elif args.input_format == 'json':
+        with open(args.input, 'r') as f:
+            json_data = json.load(f)
+
+        message = schema.new_message()
+        fpga_interchange.converters.from_yaml(message, json_data)
+    elif args.input_format == 'yaml':
+        with open(args.input, 'r') as f:
+            yaml_string = f.read()
+
+        yaml_data = yaml.load(yaml_string, Loader=SafeLoader)
+        message = schema.new_message()
+        fpga_interchange.converters.from_yaml(message, json_data)
+    else:
+        assert False, 'Invalid input format {}'.format(args.input_format)
+
+    if args.output_format == 'capnp':
+        with open(args.output, 'wb') as f:
+            write_capnp_file(message, f)
+    elif args.input_format == 'json':
+        json_data = fpga_interchange.converters.to_yaml(message)
+        with open(args.output, 'w') as f:
+            json.dump(json_data, f)
+    elif args.input_format == 'yaml':
+        yaml_data = fpga_interchange.converters.to_yaml(message)
+        yaml_string = yaml.dump(yaml_data, Dumper=Dumper)
+        with open(args.output, 'w') as f:
+            f.write(yaml_string)
+    else:
+        assert False, 'Invalid output format {}'.format(args.output_format)
+
+if __name__ == "__main__":
+    main()

--- a/fpga_interchange/converters.py
+++ b/fpga_interchange/converters.py
@@ -46,7 +46,9 @@ class BaseReaderWriter():
 
     def get_field_value(self, field, value):
         if field not in self.value_cache:
-            self.value_cache[field] = [v for v in getattr(self.struct_reader, field)]
+            self.value_cache[field] = [
+                v for v in getattr(self.struct_reader, field)
+            ]
 
         return self.value_cache[field][value]
 
@@ -58,7 +60,8 @@ class BaseReaderWriter():
 
     def get_field_cache(self, annotation_cache, schema, schema_node_id):
         if schema_node_id not in self.field_cache:
-            self.field_cache[schema_node_id] = FieldCache(annotation_cache, schema)
+            self.field_cache[schema_node_id] = FieldCache(
+                annotation_cache, schema)
         return self.field_cache[schema_node_id]
 
 
@@ -79,7 +82,8 @@ def to_writer(struct_reader,
     if schema_node_id is None:
         schema_node_id = schema.node.id
 
-    field_cache = root.get_field_cache(annotation_cache, schema, schema_node_id)
+    field_cache = root.get_field_cache(annotation_cache, schema,
+                                       schema_node_id)
 
     fields = field_cache.fields(struct_reader)
 
@@ -121,7 +125,7 @@ def to_writer(struct_reader,
                     parent=writer,
                     annotation_cache=annotation_cache,
                     schema_node_id=field_proto_data.schema_node_id,
-                    ))
+                ))
         elif field_which == 'list':
             list_which = field_proto_data.list_which
 
@@ -129,8 +133,7 @@ def to_writer(struct_reader,
             if list_which == 'struct':
                 for elem in value:
                     writer.append_to_list(
-                        data,
-                        list_which,
+                        data, list_which,
                         to_writer(
                             elem,
                             writer_class,
@@ -140,7 +143,8 @@ def to_writer(struct_reader,
                             schema_node_id=field_proto_data.schema_node_id))
             else:
                 for elem in value:
-                    writer.append_to_list(data, list_which, deference_fun(elem))
+                    writer.append_to_list(data, list_which,
+                                          deference_fun(elem))
 
             set_value(field_which, data)
         elif field_which == 'void':
@@ -173,9 +177,11 @@ def from_reader(message,
     if schema_node_id is None:
         schema_node_id = schema.node.id
 
-    field_cache = root.get_field_cache(annotation_cache, schema, schema_node_id)
+    field_cache = root.get_field_cache(annotation_cache, schema,
+                                       schema_node_id)
 
-    fields, defered_fields, union_field = field_cache.get_reader_fields(reader.keys())
+    fields, defered_fields, union_field = field_cache.get_reader_fields(
+        reader.keys())
 
     for key, annotation_value in defered_fields.items():
         reader.objects[key] = init_implementation(annotation_value)

--- a/fpga_interchange/converters.py
+++ b/fpga_interchange/converters.py
@@ -234,7 +234,8 @@ def from_reader(message,
                         schema_node_id=field_proto_data.schema_node_id)
             else:
                 for idx, elem in enumerate(field_data):
-                    list_builder[idx] = reference_fun(elem)
+                    value = reference_fun(elem)
+                    list_builder[idx] = reader.read_scalar(list_which, value)
         elif field_which == 'void':
             assert field_data is None
             setattr(builder, key, None)
@@ -243,7 +244,9 @@ def from_reader(message,
         else:
             assert field_which in SCALAR_TYPES, field_which
 
-            setattr(builder, key, reference_fun(field_data))
+            value = reference_fun(field_data)
+            value = reader.read_scalar(field_which, value)
+            setattr(builder, key, value)
 
     for field in defered_fields:
         reader.objects[field].write_message(message, field)

--- a/fpga_interchange/converters.py
+++ b/fpga_interchange/converters.py
@@ -9,6 +9,7 @@
 #
 # SPDX-License-Identifier: ISC
 from fpga_interchange.annotations import AnnotationCache
+from collections import namedtuple
 
 
 class Enumerator():
@@ -54,11 +55,149 @@ SCALAR_TYPES = [
 ]
 
 
-class YamlWriter():
-    def __init__(self, struct_reader, parent):
-        self.out = {}
-        self.struct_reader = struct_reader
-        self.parent = parent
+FieldProtoData = namedtuple('FieldProtoData', 'field_proto ref_annotation imp_annotation hide_field field_type field_which')
+ReferenceAnnotation = namedtuple('ReferenceAnnotation', 'type field depth')
+
+
+def make_reference_annotation(annotation_value):
+    type = annotation_value.type
+    field = annotation_value.field
+    depth = None
+
+    if type == 'parent':
+        depth = annotation_value.depth
+
+    return ReferenceAnnotation(
+            type=type,
+            field=field,
+            depth=depth)
+
+def make_field_proto(annotation_cache, schema_node_id, field_idx, field_proto):
+    field_type = field_proto.slot.type
+    field_which = field_type.which()
+
+    ref_annotation = None
+    imp_annotation = None
+    hide_field = False
+    for annotation_idx, annotation in enumerate(field_proto.annotations):
+        _, annotation_value = annotation_cache.get_annotation_value(
+            schema_node_id, field_idx, annotation_idx, annotation)
+        if annotation_cache.is_reference_annotation(annotation):
+            assert ref_annotation is None
+            ref_annotation = make_reference_annotation(annotation_value)
+
+        if annotation_cache.is_implementation_annotation(annotation):
+            assert imp_annotation is None
+            imp_annotation = annotation_value
+            hide_field = imp_annotation.hide
+
+    return FieldProtoData(
+            field_proto=field_proto,
+            ref_annotation=ref_annotation,
+            imp_annotation=imp_annotation,
+            hide_field=hide_field,
+            field_type=field_type,
+            field_which=field_which)
+
+
+class FieldData():
+    def __init__(self, field_cache, field_index, field):
+        self.field_cache = field_cache
+        self.field_index = field_index
+        self.field = field
+        field_proto = field.proto
+        self.key = field_proto.name
+        self.which = field_proto.which()
+
+        if self.which == 'group':
+            self.field_proto = None
+            self.group_protos = {}
+        else:
+            assert self.which == 'slot', self.which
+            self.field_proto = make_field_proto(
+                    annotation_cache=self.field_cache.annotation_cache,
+                    schema_node_id=self.field_cache.schema_node_id,
+                    field_idx=field_index,
+                    field_proto=field_proto,
+                    )
+            self.group_protos = None
+
+    def get_field_proto(self):
+        return self.field_proto
+
+    def get_group_proto(self, inner_key):
+        group_proto = self.group_protos.get(inner_key, None)
+        if group_proto is None:
+            group_proto = self.field.schema.fields[inner_key].proto
+            self.group_protos[inner_key] = make_field_proto(
+                    annotation_cache=self.field_cache.annotation_cache,
+                    schema_node_id=self.field_cache.schema_node_id,
+                    field_idx=self.field_index,
+                    field_proto=group_proto,
+                    )
+
+        return self.group_protos[inner_key]
+
+
+class FieldCache():
+    def __init__(self, annotation_cache, schema):
+        self.annotation_cache = annotation_cache
+        self.schema = schema
+        self.schema_node_id = schema.node.id
+        self.has_union_fields = bool(schema.union_fields)
+        self.field_data = {}
+        self.base_fields = set(schema.non_union_fields)
+        self.union_fields = set(schema.union_fields)
+        self.fields_list = []
+
+        for idx, field in enumerate(schema.fields_list):
+            self.fields_list.append(FieldData(self, idx, field))
+
+    def fields(self, struct_reader):
+        if self.has_union_fields:
+            fields = set(self.base_fields)
+            fields.add(struct_reader.which())
+            return fields
+        else:
+            return self.base_fields
+
+    def get_reader_fields(self, input_fields):
+        fields = set(self.base_fields)
+        defered_fields = {}
+
+        union_field = None
+        for field in self.union_fields:
+            if field in input_fields:
+                assert union_field is None, (field, union_field)
+                union_field = field
+                fields.add(field)
+
+        for field_data in self.fields_list:
+            key = field_data.key
+            if key not in fields:
+                continue
+
+            which = field_data.which
+            if which != 'slot':
+                continue
+
+            if field_data.field_proto.imp_annotation is not None:
+                defered_fields[key] = field_data.field_proto.imp_annotation
+
+        return fields, defered_fields, union_field
+
+
+
+class BaseReaderWriter():
+    def __init__(self):
+        self.field_cache = {}
+        self.value_cache = {}
+
+    def get_field_value(self, field, value):
+        if field not in self.value_cache:
+            self.value_cache[field] = [v for v in getattr(self.struct_reader, field)]
+
+        return self.value_cache[field][value]
 
     def get_parent(self, depth):
         if depth == 0:
@@ -66,13 +205,25 @@ class YamlWriter():
         else:
             return self.parent.get_parent(depth - 1)
 
+    def get_field_cache(self, annotation_cache, schema, schema_node_id):
+        if schema_node_id not in self.field_cache:
+            self.field_cache[schema_node_id] = FieldCache(annotation_cache, schema)
+        return self.field_cache[schema_node_id]
+
+
+class YamlWriter(BaseReaderWriter):
+    def __init__(self, struct_reader, parent):
+        super().__init__()
+        self.out = {}
+        self.struct_reader = struct_reader
+        self.parent = parent
+
     def dereference_value(self, annotation_type, value, root_writer,
                           parent_writer):
         if annotation_type.type == 'root':
             return root_writer.out[annotation_type.field][value]
         elif annotation_type.type == 'rootValue':
-            return getattr(root_writer.struct_reader,
-                           annotation_type.field)[value]
+            return root_writer.get_field_value(annotation_type.field, value)
         else:
             assert annotation_type.type == 'parent'
             return self.get_parent(
@@ -94,19 +245,14 @@ class YamlWriter():
         return self.out
 
 
-class JsonWriter():
+class JsonWriter(BaseReaderWriter):
     def __init__(self, struct_reader, parent):
+        super().__init__()
         self.out = {}
         self.struct_reader = struct_reader
         self.next_id = 0
         self.obj_id_cache = {}
         self.parent = parent
-
-    def get_parent(self, depth):
-        if depth == 0:
-            return self
-        else:
-            return self.parent.get_parent(depth - 1)
 
     def get_object_with_id(self, field, value):
         item = self.out[field][value]
@@ -132,8 +278,7 @@ class JsonWriter():
         if annotation_type.type == 'root':
             return root_writer.get_object_with_id(annotation_type.field, value)
         elif annotation_type.type == 'rootValue':
-            return getattr(root_writer.struct_reader,
-                           annotation_type.field)[value]
+            return root_writer.get_field_value(annotation_type.field, value)
         else:
             assert annotation_type.type == 'parent'
             return self.get_parent(annotation_type.depth).get_object_with_id(
@@ -170,51 +315,39 @@ def to_writer(struct_reader,
     schema = struct_reader.schema
     schema_node_id = schema.node.id
 
-    fields = set(schema.non_union_fields)
-    if schema.union_fields:
-        fields.add(struct_reader.which())
+    field_cache = root.get_field_cache(annotation_cache, schema, schema_node_id)
 
-    for field_idx, field in enumerate(schema.fields_list):
-        key = field.proto.name
+    fields = field_cache.fields(struct_reader)
+
+    for field_idx, field in enumerate(field_cache.fields_list):
+        key = field.key
         if key not in fields:
             continue
 
-        which = field.proto.which()
+        which = field.which
         if which == 'group':
             group = getattr(struct_reader, key)
             inner_key = group.which()
             value = getattr(group, inner_key)
 
             set_value = lambda value: writer.set_value_inner_key(key, inner_key, value)
-            field_proto = field.schema.fields[inner_key].proto
+            field_proto_data = field.get_group_proto(inner_key)
         else:
             assert which == 'slot', which
             value = getattr(struct_reader, key)
             set_value = lambda value: writer.set_value(key, value)
-            field_proto = field.proto
+            field_proto_data = field.get_field_proto()
 
-        deference_fun = None
-        hide_field = False
-        for annotation_idx, annotation in enumerate(field_proto.annotations):
-            _, annotation_value = annotation_cache.get_annotation_value(
-                schema_node_id, field_idx, annotation_idx, annotation)
-            if annotation_cache.is_reference_annotation(annotation):
-                assert deference_fun is None
-                deference_fun = lambda value: writer.dereference_value(annotation_value, value, root, parent)
-
-            if annotation_cache.is_implementation_annotation(annotation):
-                if annotation_value.hide:
-                    hide_field = True
-
-        if hide_field:
-            continue
-
-        if deference_fun is None:
+        if field_proto_data.ref_annotation is not None:
+            deference_fun = lambda value: writer.dereference_value(field_proto_data.ref_annotation, value, root, parent)
+        else:
             deference_fun = lambda value: value
 
-        field_type = field_proto.slot.type
+        if field_proto_data.hide_field:
+            continue
 
-        field_which = field_type.which()
+        field_type = field_proto_data.field_type
+        field_which = field_proto_data.field_which
         if field_which == 'struct':
             set_value(
                 to_writer(
@@ -277,19 +410,14 @@ class IndexCache():
         return self.caches[field][id(value)]
 
 
-class YamlReader():
+class YamlReader(BaseReaderWriter):
     def __init__(self, message, data, parent):
+        super().__init__()
         self.message = message
         self.data = data
         self.objects = {}
         self.index_cache = IndexCache(self.data)
         self.parent = parent
-
-    def get_parent(self, depth):
-        if depth == 0:
-            return self
-        else:
-            return self.parent.get_parent(depth - 1)
 
     def get_index(self, field, value):
         return self.index_cache.get_index(field, value)
@@ -320,19 +448,14 @@ class JsonIndexCache():
         return self.caches[field][value['_id']]
 
 
-class JsonReader():
+class JsonReader(BaseReaderWriter):
     def __init__(self, message, data, parent):
+        super().__init__()
         self.message = message
         self.data = data
         self.objects = {}
         self.index_cache = JsonIndexCache(self.data)
         self.parent = parent
-
-    def get_parent(self, depth):
-        if depth == 0:
-            return self
-        else:
-            return self.parent.get_parent(depth - 1)
 
     def get_index(self, field, value):
         return self.index_cache.get_index(field, value)
@@ -365,42 +488,19 @@ def from_reader(message,
     schema = message.schema
     schema_node_id = schema.node.id
 
-    fields = set(schema.non_union_fields)
-    defered_fields = set()
+    field_cache = root.get_field_cache(annotation_cache, schema, schema_node_id)
 
-    union_field = None
-    for field in schema.union_fields:
-        if field in data:
-            assert union_field is None, (field, union_field)
-            union_field = field
-            fields.add(field)
+    fields, defered_fields, union_field = field_cache.get_reader_fields(data.keys())
 
-    for field_idx, field in enumerate(schema.fields_list):
-        key = field.proto.name
-        if key not in fields:
-            continue
+    for key, annotation_value in defered_fields.items():
+        reader.objects[key] = init_implementation(annotation_value)
 
-        which = field.proto.which()
-        if which != 'slot':
-            continue
-
-        for annotation_idx, annotation in enumerate(field.proto.annotations):
-            _, annotation_value = annotation_cache.get_annotation_value(
-                schema_node_id, field_idx, annotation_idx, annotation)
-            if annotation_cache.is_implementation_annotation(annotation):
-                if annotation_value.hide:
-                    reader.objects[key] = init_implementation(annotation_value)
-                    defered_fields.add(key)
-
-    for field in defered_fields:
-        assert field not in data
-
-    for field_idx, field in enumerate(schema.fields_list):
-        key = field.proto.name
+    for field_idx, field in enumerate(field_cache.fields_list):
+        key = field.key
         if key not in fields or key in defered_fields:
             continue
 
-        which = field.proto.which()
+        which = field.which
         if which == 'group':
             keys = list(data[key].keys())
             assert len(keys) == 1, keys
@@ -408,33 +508,22 @@ def from_reader(message,
             builder = getattr(message, key)
             field_data = data[key][inner_key]
             key = inner_key
-            field_proto = field.schema.fields[inner_key].proto
+            field_proto_data = field.get_group_proto(inner_key)
         else:
             builder = message
             field_data = data[key]
-            field_proto = field.proto
+            field_proto_data = field.get_field_proto()
 
-        reference_fun = None
-        hide_field = False
-        for annotation_idx, annotation in enumerate(field_proto.annotations):
-            _, annotation_value = annotation_cache.get_annotation_value(
-                schema_node_id, field_idx, annotation_idx, annotation)
-            if annotation_cache.is_reference_annotation(annotation):
-                assert reference_fun is None
-                reference_fun = lambda value: reader.reference_value(annotation_value, value, root, parent)
-
-            if annotation_cache.is_implementation_annotation(annotation):
-                if annotation_value.hide:
-                    hide_field = True
-
-        if reference_fun is None:
-            reference_fun = lambda value: value
-
-        if hide_field:
+        if field_proto_data.hide_field:
             continue
 
-        field_type = field_proto.slot.type
-        field_which = field_type.which()
+        if field_proto_data.ref_annotation is not None:
+            reference_fun = lambda value: reader.reference_value(field_proto_data.ref_annotation, value, root, parent)
+        else:
+            reference_fun = lambda value: value
+
+        field_type = field_proto_data.field_type
+        field_which = field_proto_data.field_which
         if field_which == 'struct':
             builder.init(key)
             from_reader(

--- a/fpga_interchange/converters.py
+++ b/fpga_interchange/converters.py
@@ -11,8 +11,6 @@
 from fpga_interchange.annotations import AnnotationCache
 
 
-
-
 class Enumerator():
     def __init__(self):
         self.values = []
@@ -39,20 +37,21 @@ def init_implementation(annotation_value):
     else:
         raise NotImplementedError()
 
+
 SCALAR_TYPES = [
-                'bool',
-                'int8',
-                'int16',
-                'int32',
-                'int64',
-                'uint8',
-                'uint16',
-                'uint32',
-                'uint64',
-                'float32',
-                'float64',
-                'text',
-            ]
+    'bool',
+    'int8',
+    'int16',
+    'int32',
+    'int64',
+    'uint8',
+    'uint16',
+    'uint32',
+    'uint64',
+    'float32',
+    'float64',
+    'text',
+]
 
 
 class YamlWriter():
@@ -65,16 +64,19 @@ class YamlWriter():
         if depth == 0:
             return self
         else:
-            return self.parent.get_parent(depth-1)
+            return self.parent.get_parent(depth - 1)
 
-    def dereference_value(self, annotation_type, value, root_writer, parent_writer):
+    def dereference_value(self, annotation_type, value, root_writer,
+                          parent_writer):
         if annotation_type.type == 'root':
             return root_writer.out[annotation_type.field][value]
         elif annotation_type.type == 'rootValue':
-            return getattr(root_writer.struct_reader, annotation_type.field)[value]
+            return getattr(root_writer.struct_reader,
+                           annotation_type.field)[value]
         else:
             assert annotation_type.type == 'parent'
-            return self.get_parent(annotation_type.depth).out[annotation_type.field][value]
+            return self.get_parent(
+                annotation_type.depth).out[annotation_type.field][value]
 
     def set_value(self, key, value):
         self.out[key] = value
@@ -104,7 +106,7 @@ class JsonWriter():
         if depth == 0:
             return self
         else:
-            return self.parent.get_parent(depth-1)
+            return self.parent.get_parent(depth - 1)
 
     def get_object_with_id(self, field, value):
         item = self.out[field][value]
@@ -121,18 +123,21 @@ class JsonWriter():
             assert item['_id'] == item_id, (
                 item['_id'],
                 item_id,
-                )
+            )
 
         return item
 
-    def dereference_value(self, annotation_type, value, root_writer, parent_writer):
+    def dereference_value(self, annotation_type, value, root_writer,
+                          parent_writer):
         if annotation_type.type == 'root':
             return root_writer.get_object_with_id(annotation_type.field, value)
         elif annotation_type.type == 'rootValue':
-            return getattr(root_writer.struct_reader, annotation_type.field)[value]
+            return getattr(root_writer.struct_reader,
+                           annotation_type.field)[value]
         else:
             assert annotation_type.type == 'parent'
-            return self.get_parent(annotation_type.depth).get_object_with_id(annotation_type.field, value)
+            return self.get_parent(annotation_type.depth).get_object_with_id(
+                annotation_type.field, value)
 
     def set_value(self, key, value):
         self.out[key] = value
@@ -150,7 +155,11 @@ class JsonWriter():
         return self.out
 
 
-def to_writer(struct_reader, writer_class, root=None, parent=None, annotation_cache=None):
+def to_writer(struct_reader,
+              writer_class,
+              root=None,
+              parent=None,
+              annotation_cache=None):
     writer = writer_class(struct_reader, parent)
     if root is None:
         root = writer
@@ -207,7 +216,13 @@ def to_writer(struct_reader, writer_class, root=None, parent=None, annotation_ca
 
         field_which = field_type.which()
         if field_which == 'struct':
-            set_value(to_writer(value, writer_class, root=root, parent=writer, annotation_cache=annotation_cache))
+            set_value(
+                to_writer(
+                    value,
+                    writer_class,
+                    root=root,
+                    parent=writer,
+                    annotation_cache=annotation_cache))
         elif field_which == 'list':
             list_type = field_type.list.elementType
             list_which = list_type.which()
@@ -215,7 +230,14 @@ def to_writer(struct_reader, writer_class, root=None, parent=None, annotation_ca
             data = writer.make_list()
             if list_which == 'struct':
                 for elem in value:
-                    writer.append_to_list(data, to_writer(elem, writer_class, root=root, parent=writer, annotation_cache=annotation_cache))
+                    writer.append_to_list(
+                        data,
+                        to_writer(
+                            elem,
+                            writer_class,
+                            root=root,
+                            parent=writer,
+                            annotation_cache=annotation_cache))
             else:
                 for elem in value:
                     writer.append_to_list(data, deference_fun(elem))
@@ -267,19 +289,21 @@ class YamlReader():
         if depth == 0:
             return self
         else:
-            return self.parent.get_parent(depth-1)
+            return self.parent.get_parent(depth - 1)
 
     def get_index(self, field, value):
         return self.index_cache.get_index(field, value)
 
-    def reference_value(self, annotation_type, value, root_reader, parent_reader):
+    def reference_value(self, annotation_type, value, root_reader,
+                        parent_reader):
         if annotation_type.type == 'root':
             return root_reader.get_index(annotation_type.field, value)
         elif annotation_type.type == 'rootValue':
             return root_reader.objects[annotation_type.field].get_index(value)
         else:
             assert annotation_type.type == 'parent'
-            return self.get_parent(annotation_type.depth).get_index(annotation_type.field, value)
+            return self.get_parent(annotation_type.depth).get_index(
+                annotation_type.field, value)
 
 
 class JsonIndexCache():
@@ -308,21 +332,29 @@ class JsonReader():
         if depth == 0:
             return self
         else:
-            return self.parent.get_parent(depth-1)
+            return self.parent.get_parent(depth - 1)
 
     def get_index(self, field, value):
         return self.index_cache.get_index(field, value)
 
-    def reference_value(self, annotation_type, value, root_reader, parent_reader):
+    def reference_value(self, annotation_type, value, root_reader,
+                        parent_reader):
         if annotation_type.type == 'root':
             return root_reader.get_index(annotation_type.field, value)
         elif annotation_type.type == 'rootValue':
             return root_reader.objects[annotation_type.field].get_index(value)
         else:
             assert annotation_type.type == 'parent'
-            return self.get_parent(annotation_type.depth).get_index(annotation_type.field, value)
+            return self.get_parent(annotation_type.depth).get_index(
+                annotation_type.field, value)
 
-def from_reader(message, data, reader_class, root=None, parent=None, annotation_cache=None):
+
+def from_reader(message,
+                data,
+                reader_class,
+                root=None,
+                parent=None,
+                annotation_cache=None):
     reader = reader_class(message, data, parent)
     if root is None:
         root = reader
@@ -442,8 +474,10 @@ def from_reader(message, data, reader_class, root=None, parent=None, annotation_
     for field in defered_fields:
         reader.objects[field].write_message(message, field)
 
+
 def from_yaml(message, data):
     from_reader(message, data, YamlReader)
+
 
 def from_json(message, data):
     from_reader(message, data, JsonReader)

--- a/fpga_interchange/converters.py
+++ b/fpga_interchange/converters.py
@@ -11,14 +11,6 @@
 from fpga_interchange.annotations import AnnotationCache
 
 
-def dereference_value(annotation_type, value, root):
-    if annotation_type.type == 'root':
-        return root[1][annotation_type.field][value]
-    elif annotation_type.type == 'rootValue':
-        return getattr(root[0], annotation_type.field)[value]
-    else:
-        assert annotation_type.type == 'parent'
-        raise NotImplementedError()
 
 
 class Enumerator():
@@ -47,20 +39,133 @@ def init_implementation(annotation_value):
     else:
         raise NotImplementedError()
 
+SCALAR_TYPES = [
+                'bool',
+                'int8',
+                'int16',
+                'int32',
+                'int64',
+                'uint8',
+                'uint16',
+                'uint32',
+                'uint64',
+                'float32',
+                'float64',
+                'text',
+            ]
 
-def to_yaml(struct_reader, root=None, annotation_cache=None):
-    out = {}
+
+class YamlWriter():
+    def __init__(self, struct_reader, parent):
+        self.out = {}
+        self.struct_reader = struct_reader
+        self.parent = parent
+
+    def get_parent(self, depth):
+        if depth == 0:
+            return self
+        else:
+            return self.parent.get_parent(depth-1)
+
+    def dereference_value(self, annotation_type, value, root_writer, parent_writer):
+        if annotation_type.type == 'root':
+            return root_writer.out[annotation_type.field][value]
+        elif annotation_type.type == 'rootValue':
+            return getattr(root_writer.struct_reader, annotation_type.field)[value]
+        else:
+            assert annotation_type.type == 'parent'
+            return self.get_parent(annotation_type.depth).out[annotation_type.field][value]
+
+    def set_value(self, key, value):
+        self.out[key] = value
+
+    def set_value_inner_key(self, key, inner_key, value):
+        self.out.update({key: {inner_key: value}})
+
+    def make_list(self):
+        return []
+
+    def append_to_list(self, l, value):
+        l.append(value)
+
+    def output(self):
+        return self.out
+
+
+class JsonWriter():
+    def __init__(self, struct_reader, parent):
+        self.out = {}
+        self.struct_reader = struct_reader
+        self.next_id = 0
+        self.obj_id_cache = {}
+        self.parent = parent
+
+    def get_parent(self, depth):
+        if depth == 0:
+            return self
+        else:
+            return self.parent.get_parent(depth-1)
+
+    def get_object_with_id(self, field, value):
+        item = self.out[field][value]
+
+        if id(item) not in self.obj_id_cache:
+            self.obj_id_cache[id(item)] = self.next_id
+            self.next_id += 1
+
+        item_id = self.obj_id_cache[id(item)]
+
+        if '_id' not in item:
+            item['_id'] = item_id
+        else:
+            assert item['_id'] == item_id, (
+                item['_id'],
+                item_id,
+                )
+
+        return item
+
+    def dereference_value(self, annotation_type, value, root_writer, parent_writer):
+        if annotation_type.type == 'root':
+            return root_writer.get_object_with_id(annotation_type.field, value)
+        elif annotation_type.type == 'rootValue':
+            return getattr(root_writer.struct_reader, annotation_type.field)[value]
+        else:
+            assert annotation_type.type == 'parent'
+            return self.get_parent(annotation_type.depth).get_object_with_id(annotation_type.field, value)
+
+    def set_value(self, key, value):
+        self.out[key] = value
+
+    def set_value_inner_key(self, key, inner_key, value):
+        self.out.update({key: {inner_key: value}})
+
+    def make_list(self):
+        return []
+
+    def append_to_list(self, l, value):
+        l.append(value)
+
+    def output(self):
+        return self.out
+
+
+def to_writer(struct_reader, writer_class, root=None, parent=None, annotation_cache=None):
+    writer = writer_class(struct_reader, parent)
     if root is None:
+        root = writer
+
+    if annotation_cache is None:
         annotation_cache = AnnotationCache()
-        root = [struct_reader, out, annotation_cache]
 
     schema = struct_reader.schema
+    schema_node_id = schema.node.id
 
     fields = set(schema.non_union_fields)
     if schema.union_fields:
         fields.add(struct_reader.which())
 
-    for field in schema.fields_list:
+    for field_idx, field in enumerate(schema.fields_list):
         key = field.proto.name
         if key not in fields:
             continue
@@ -71,22 +176,22 @@ def to_yaml(struct_reader, root=None, annotation_cache=None):
             inner_key = group.which()
             value = getattr(group, inner_key)
 
-            set_value = lambda value: out.update({key: {inner_key: value}})
+            set_value = lambda value: writer.set_value_inner_key(key, inner_key, value)
             field_proto = field.schema.fields[inner_key].proto
         else:
             assert which == 'slot', which
             value = getattr(struct_reader, key)
-            set_value = lambda value: out.update({key: value})
+            set_value = lambda value: writer.set_value(key, value)
             field_proto = field.proto
 
         deference_fun = None
         hide_field = False
-        for annotation in field_proto.annotations:
+        for annotation_idx, annotation in enumerate(field_proto.annotations):
             _, annotation_value = annotation_cache.get_annotation_value(
-                annotation)
+                schema_node_id, field_idx, annotation_idx, annotation)
             if annotation_cache.is_reference_annotation(annotation):
                 assert deference_fun is None
-                deference_fun = lambda value: dereference_value(annotation_value, value, root)
+                deference_fun = lambda value: writer.dereference_value(annotation_value, value, root, parent)
 
             if annotation_cache.is_implementation_annotation(annotation):
                 if annotation_value.hide:
@@ -102,18 +207,18 @@ def to_yaml(struct_reader, root=None, annotation_cache=None):
 
         field_which = field_type.which()
         if field_which == 'struct':
-            set_value(to_yaml(value, root, annotation_cache))
+            set_value(to_writer(value, writer_class, root=root, parent=writer, annotation_cache=annotation_cache))
         elif field_which == 'list':
             list_type = field_type.list.elementType
             list_which = list_type.which()
 
-            data = []
+            data = writer.make_list()
             if list_which == 'struct':
                 for elem in value:
-                    data.append(to_yaml(elem, root, annotation_cache))
+                    writer.append_to_list(data, to_writer(elem, writer_class, root=root, parent=writer, annotation_cache=annotation_cache))
             else:
                 for elem in value:
-                    data.append(deference_fun(elem))
+                    writer.append_to_list(data, deference_fun(elem))
 
             set_value(data)
         elif field_which == 'void':
@@ -121,24 +226,19 @@ def to_yaml(struct_reader, root=None, annotation_cache=None):
         elif field_which == 'enum':
             set_value(value._as_str())
         else:
-            assert field_which in [
-                'bool',
-                'int8',
-                'int16',
-                'int32',
-                'int64',
-                'uint8',
-                'uint16',
-                'uint32',
-                'uint64',
-                'float32',
-                'float64',
-                'text',
-            ], field_which
+            assert field_which in SCALAR_TYPES, field_which
 
             set_value(deference_fun(value))
 
-    return out
+    return writer.output()
+
+
+def to_yaml(struct_reader):
+    return to_writer(struct_reader, YamlWriter)
+
+
+def to_json(struct_reader):
+    return to_writer(struct_reader, JsonWriter)
 
 
 class IndexCache():
@@ -155,23 +255,83 @@ class IndexCache():
         return self.caches[field][id(value)]
 
 
-def reference_value(annotation_type, value, root):
-    if annotation_type.type == 'root':
-        return root[2].get_index(annotation_type.field, value)
-    elif annotation_type.type == 'rootValue':
-        return root[1][annotation_type.field].get_index(value)
-    else:
-        assert annotation_type.type == 'parent'
-        raise NotImplementedError()
+class YamlReader():
+    def __init__(self, message, data, parent):
+        self.message = message
+        self.data = data
+        self.objects = {}
+        self.index_cache = IndexCache(self.data)
+        self.parent = parent
+
+    def get_parent(self, depth):
+        if depth == 0:
+            return self
+        else:
+            return self.parent.get_parent(depth-1)
+
+    def get_index(self, field, value):
+        return self.index_cache.get_index(field, value)
+
+    def reference_value(self, annotation_type, value, root_reader, parent_reader):
+        if annotation_type.type == 'root':
+            return root_reader.get_index(annotation_type.field, value)
+        elif annotation_type.type == 'rootValue':
+            return root_reader.objects[annotation_type.field].get_index(value)
+        else:
+            assert annotation_type.type == 'parent'
+            return self.get_parent(annotation_type.depth).get_index(annotation_type.field, value)
 
 
-def from_yaml(message, data, root=None, annotation_cache=None):
-    obj = [data, {}, IndexCache(data)]
+class JsonIndexCache():
+    def __init__(self, data):
+        self.data = data
+        self.caches = {}
+
+    def get_index(self, field, value):
+        if field not in self.caches:
+            self.caches[field] = {}
+            for idx, obj in enumerate(self.data[field]):
+                self.caches[field][obj['_id']] = idx
+
+        return self.caches[field][value['_id']]
+
+
+class JsonReader():
+    def __init__(self, message, data, parent):
+        self.message = message
+        self.data = data
+        self.objects = {}
+        self.index_cache = JsonIndexCache(self.data)
+        self.parent = parent
+
+    def get_parent(self, depth):
+        if depth == 0:
+            return self
+        else:
+            return self.parent.get_parent(depth-1)
+
+    def get_index(self, field, value):
+        return self.index_cache.get_index(field, value)
+
+    def reference_value(self, annotation_type, value, root_reader, parent_reader):
+        if annotation_type.type == 'root':
+            return root_reader.get_index(annotation_type.field, value)
+        elif annotation_type.type == 'rootValue':
+            return root_reader.objects[annotation_type.field].get_index(value)
+        else:
+            assert annotation_type.type == 'parent'
+            return self.get_parent(annotation_type.depth).get_index(annotation_type.field, value)
+
+def from_reader(message, data, reader_class, root=None, parent=None, annotation_cache=None):
+    reader = reader_class(message, data, parent)
     if root is None:
-        root = obj
+        root = reader
+
+    if annotation_cache is None:
         annotation_cache = AnnotationCache()
 
     schema = message.schema
+    schema_node_id = schema.node.id
 
     fields = set(schema.non_union_fields)
     defered_fields = set()
@@ -183,7 +343,7 @@ def from_yaml(message, data, root=None, annotation_cache=None):
             union_field = field
             fields.add(field)
 
-    for field in schema.fields_list:
+    for field_idx, field in enumerate(schema.fields_list):
         key = field.proto.name
         if key not in fields:
             continue
@@ -192,18 +352,18 @@ def from_yaml(message, data, root=None, annotation_cache=None):
         if which != 'slot':
             continue
 
-        for annotation in field.proto.annotations:
+        for annotation_idx, annotation in enumerate(field.proto.annotations):
             _, annotation_value = annotation_cache.get_annotation_value(
-                annotation)
+                schema_node_id, field_idx, annotation_idx, annotation)
             if annotation_cache.is_implementation_annotation(annotation):
                 if annotation_value.hide:
-                    obj[1][key] = init_implementation(annotation_value)
+                    reader.objects[key] = init_implementation(annotation_value)
                     defered_fields.add(key)
 
     for field in defered_fields:
         assert field not in data
 
-    for field in schema.fields_list:
+    for field_idx, field in enumerate(schema.fields_list):
         key = field.proto.name
         if key not in fields or key in defered_fields:
             continue
@@ -224,12 +384,12 @@ def from_yaml(message, data, root=None, annotation_cache=None):
 
         reference_fun = None
         hide_field = False
-        for annotation in field_proto.annotations:
+        for annotation_idx, annotation in enumerate(field_proto.annotations):
             _, annotation_value = annotation_cache.get_annotation_value(
-                annotation)
+                schema_node_id, field_idx, annotation_idx, annotation)
             if annotation_cache.is_reference_annotation(annotation):
                 assert reference_fun is None
-                reference_fun = lambda value: reference_value(annotation_value, value, root)
+                reference_fun = lambda value: reader.reference_value(annotation_value, value, root, parent)
 
             if annotation_cache.is_implementation_annotation(annotation):
                 if annotation_value.hide:
@@ -245,8 +405,13 @@ def from_yaml(message, data, root=None, annotation_cache=None):
         field_which = field_type.which()
         if field_which == 'struct':
             builder.init(key)
-            from_yaml(
-                getattr(builder, key), field_data, root, annotation_cache)
+            from_reader(
+                message=getattr(builder, key),
+                data=field_data,
+                reader_class=reader_class,
+                root=root,
+                parent=reader,
+                annotation_cache=annotation_cache)
         elif field_which == 'list':
             list_builder = builder.init(key, len(field_data))
             list_type = field_type.list.elementType
@@ -254,7 +419,13 @@ def from_yaml(message, data, root=None, annotation_cache=None):
 
             if list_which == 'struct':
                 for elem_builder, elem in zip(list_builder, field_data):
-                    from_yaml(elem_builder, elem, root, annotation_cache)
+                    from_reader(
+                        message=elem_builder,
+                        data=elem,
+                        reader_class=reader_class,
+                        root=root,
+                        parent=reader,
+                        annotation_cache=annotation_cache)
             else:
                 for idx, elem in enumerate(field_data):
                     list_builder[idx] = reference_fun(elem)
@@ -264,22 +435,15 @@ def from_yaml(message, data, root=None, annotation_cache=None):
         elif field_which == 'enum':
             setattr(builder, key, field_data)
         else:
-            assert field_which in [
-                'bool',
-                'int8',
-                'int16',
-                'int32',
-                'int64',
-                'uint8',
-                'uint16',
-                'uint32',
-                'uint64',
-                'float32',
-                'float64',
-                'text',
-            ], field_which
+            assert field_which in SCALAR_TYPES, field_which
 
             setattr(builder, key, reference_fun(field_data))
 
     for field in defered_fields:
-        obj[1][field].write_message(message, field)
+        reader.objects[field].write_message(message, field)
+
+def from_yaml(message, data):
+    from_reader(message, data, YamlReader)
+
+def from_json(message, data):
+    from_reader(message, data, JsonReader)

--- a/fpga_interchange/converters.py
+++ b/fpga_interchange/converters.py
@@ -1,3 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
 from fpga_interchange.annotations import AnnotationCache
 
 

--- a/fpga_interchange/converters.py
+++ b/fpga_interchange/converters.py
@@ -56,7 +56,6 @@ def to_yaml(struct_reader, root=None, annotation_cache=None):
 
     schema = struct_reader.schema
 
-
     fields = set(schema.non_union_fields)
     if schema.union_fields:
         fields.add(struct_reader.which())
@@ -140,6 +139,7 @@ def to_yaml(struct_reader, root=None, annotation_cache=None):
             set_value(deference_fun(value))
 
     return out
+
 
 class IndexCache():
     def __init__(self, data):

--- a/fpga_interchange/converters.py
+++ b/fpga_interchange/converters.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-#
+
 # Copyright (C) 2020  The SymbiFlow Authors.
 #
 # Use of this source code is governed by a ISC-style
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: ISC
 from fpga_interchange.annotations import AnnotationCache
-from collections import namedtuple
+from fpga_interchange.field_cache import FieldCache, SCALAR_TYPES
 
 
 class Enumerator():
@@ -39,155 +39,6 @@ def init_implementation(annotation_value):
         raise NotImplementedError()
 
 
-SCALAR_TYPES = [
-    'bool',
-    'int8',
-    'int16',
-    'int32',
-    'int64',
-    'uint8',
-    'uint16',
-    'uint32',
-    'uint64',
-    'float32',
-    'float64',
-    'text',
-]
-
-
-FieldProtoData = namedtuple('FieldProtoData', 'field_proto ref_annotation imp_annotation hide_field field_type field_which')
-ReferenceAnnotation = namedtuple('ReferenceAnnotation', 'type field depth')
-
-
-def make_reference_annotation(annotation_value):
-    type = annotation_value.type
-    field = annotation_value.field
-    depth = None
-
-    if type == 'parent':
-        depth = annotation_value.depth
-
-    return ReferenceAnnotation(
-            type=type,
-            field=field,
-            depth=depth)
-
-def make_field_proto(annotation_cache, schema_node_id, field_idx, field_proto):
-    field_type = field_proto.slot.type
-    field_which = field_type.which()
-
-    ref_annotation = None
-    imp_annotation = None
-    hide_field = False
-    for annotation_idx, annotation in enumerate(field_proto.annotations):
-        _, annotation_value = annotation_cache.get_annotation_value(
-            schema_node_id, field_idx, annotation_idx, annotation)
-        if annotation_cache.is_reference_annotation(annotation):
-            assert ref_annotation is None
-            ref_annotation = make_reference_annotation(annotation_value)
-
-        if annotation_cache.is_implementation_annotation(annotation):
-            assert imp_annotation is None
-            imp_annotation = annotation_value
-            hide_field = imp_annotation.hide
-
-    return FieldProtoData(
-            field_proto=field_proto,
-            ref_annotation=ref_annotation,
-            imp_annotation=imp_annotation,
-            hide_field=hide_field,
-            field_type=field_type,
-            field_which=field_which)
-
-
-class FieldData():
-    def __init__(self, field_cache, field_index, field):
-        self.field_cache = field_cache
-        self.field_index = field_index
-        self.field = field
-        field_proto = field.proto
-        self.key = field_proto.name
-        self.which = field_proto.which()
-
-        if self.which == 'group':
-            self.field_proto = None
-            self.group_protos = {}
-        else:
-            assert self.which == 'slot', self.which
-            self.field_proto = make_field_proto(
-                    annotation_cache=self.field_cache.annotation_cache,
-                    schema_node_id=self.field_cache.schema_node_id,
-                    field_idx=field_index,
-                    field_proto=field_proto,
-                    )
-            self.group_protos = None
-
-    def get_field_proto(self):
-        return self.field_proto
-
-    def get_group_proto(self, inner_key):
-        group_proto = self.group_protos.get(inner_key, None)
-        if group_proto is None:
-            group_proto = self.field.schema.fields[inner_key].proto
-            self.group_protos[inner_key] = make_field_proto(
-                    annotation_cache=self.field_cache.annotation_cache,
-                    schema_node_id=self.field_cache.schema_node_id,
-                    field_idx=self.field_index,
-                    field_proto=group_proto,
-                    )
-
-        return self.group_protos[inner_key]
-
-
-class FieldCache():
-    def __init__(self, annotation_cache, schema):
-        self.annotation_cache = annotation_cache
-        self.schema = schema
-        self.schema_node_id = schema.node.id
-        self.has_union_fields = bool(schema.union_fields)
-        self.field_data = {}
-        self.base_fields = set(schema.non_union_fields)
-        self.union_fields = set(schema.union_fields)
-        self.fields_list = []
-
-        for idx, field in enumerate(schema.fields_list):
-            self.fields_list.append(FieldData(self, idx, field))
-
-    def fields(self, struct_reader):
-        if self.has_union_fields:
-            fields = set(self.base_fields)
-            fields.add(struct_reader.which())
-            return fields
-        else:
-            return self.base_fields
-
-    def get_reader_fields(self, input_fields):
-        fields = set(self.base_fields)
-        defered_fields = {}
-
-        union_field = None
-        for field in self.union_fields:
-            if field in input_fields:
-                assert union_field is None, (field, union_field)
-                union_field = field
-                fields.add(field)
-
-        for field_data in self.fields_list:
-            key = field_data.key
-            if key not in fields:
-                continue
-
-            which = field_data.which
-            if which != 'slot':
-                continue
-
-            if field_data.field_proto.imp_annotation is not None:
-                defered_fields[key] = field_data.field_proto.imp_annotation
-
-        return fields, defered_fields, union_field
-
-
-
 class BaseReaderWriter():
     def __init__(self):
         self.field_cache = {}
@@ -211,100 +62,12 @@ class BaseReaderWriter():
         return self.field_cache[schema_node_id]
 
 
-class YamlWriter(BaseReaderWriter):
-    def __init__(self, struct_reader, parent):
-        super().__init__()
-        self.out = {}
-        self.struct_reader = struct_reader
-        self.parent = parent
-
-    def dereference_value(self, annotation_type, value, root_writer,
-                          parent_writer):
-        if annotation_type.type == 'root':
-            return root_writer.out[annotation_type.field][value]
-        elif annotation_type.type == 'rootValue':
-            return root_writer.get_field_value(annotation_type.field, value)
-        else:
-            assert annotation_type.type == 'parent'
-            return self.get_parent(
-                annotation_type.depth).out[annotation_type.field][value]
-
-    def set_value(self, key, value):
-        self.out[key] = value
-
-    def set_value_inner_key(self, key, inner_key, value):
-        self.out.update({key: {inner_key: value}})
-
-    def make_list(self):
-        return []
-
-    def append_to_list(self, l, value):
-        l.append(value)
-
-    def output(self):
-        return self.out
-
-
-class JsonWriter(BaseReaderWriter):
-    def __init__(self, struct_reader, parent):
-        super().__init__()
-        self.out = {}
-        self.struct_reader = struct_reader
-        self.next_id = 0
-        self.obj_id_cache = {}
-        self.parent = parent
-
-    def get_object_with_id(self, field, value):
-        item = self.out[field][value]
-
-        if id(item) not in self.obj_id_cache:
-            self.obj_id_cache[id(item)] = self.next_id
-            self.next_id += 1
-
-        item_id = self.obj_id_cache[id(item)]
-
-        if '_id' not in item:
-            item['_id'] = item_id
-        else:
-            assert item['_id'] == item_id, (
-                item['_id'],
-                item_id,
-            )
-
-        return item
-
-    def dereference_value(self, annotation_type, value, root_writer,
-                          parent_writer):
-        if annotation_type.type == 'root':
-            return root_writer.get_object_with_id(annotation_type.field, value)
-        elif annotation_type.type == 'rootValue':
-            return root_writer.get_field_value(annotation_type.field, value)
-        else:
-            assert annotation_type.type == 'parent'
-            return self.get_parent(annotation_type.depth).get_object_with_id(
-                annotation_type.field, value)
-
-    def set_value(self, key, value):
-        self.out[key] = value
-
-    def set_value_inner_key(self, key, inner_key, value):
-        self.out.update({key: {inner_key: value}})
-
-    def make_list(self):
-        return []
-
-    def append_to_list(self, l, value):
-        l.append(value)
-
-    def output(self):
-        return self.out
-
-
 def to_writer(struct_reader,
               writer_class,
               root=None,
               parent=None,
-              annotation_cache=None):
+              annotation_cache=None,
+              schema_node_id=None):
     writer = writer_class(struct_reader, parent)
     if root is None:
         root = writer
@@ -313,7 +76,8 @@ def to_writer(struct_reader,
         annotation_cache = AnnotationCache()
 
     schema = struct_reader.schema
-    schema_node_id = schema.node.id
+    if schema_node_id is None:
+        schema_node_id = schema.node.id
 
     field_cache = root.get_field_cache(annotation_cache, schema, schema_node_id)
 
@@ -330,12 +94,12 @@ def to_writer(struct_reader,
             inner_key = group.which()
             value = getattr(group, inner_key)
 
-            set_value = lambda value: writer.set_value_inner_key(key, inner_key, value)
+            set_value = lambda value_which, value: writer.set_value_inner_key(key, inner_key, value_which, value)
             field_proto_data = field.get_group_proto(inner_key)
         else:
             assert which == 'slot', which
             value = getattr(struct_reader, key)
-            set_value = lambda value: writer.set_value(key, value)
+            set_value = lambda value_which, value: writer.set_value(key, value_which, value)
             field_proto_data = field.get_field_proto()
 
         if field_proto_data.ref_annotation is not None:
@@ -346,130 +110,49 @@ def to_writer(struct_reader,
         if field_proto_data.hide_field:
             continue
 
-        field_type = field_proto_data.field_type
         field_which = field_proto_data.field_which
         if field_which == 'struct':
             set_value(
+                field_which,
                 to_writer(
                     value,
                     writer_class,
                     root=root,
                     parent=writer,
-                    annotation_cache=annotation_cache))
+                    annotation_cache=annotation_cache,
+                    schema_node_id=field_proto_data.schema_node_id,
+                    ))
         elif field_which == 'list':
-            list_type = field_type.list.elementType
-            list_which = list_type.which()
+            list_which = field_proto_data.list_which
 
             data = writer.make_list()
             if list_which == 'struct':
                 for elem in value:
                     writer.append_to_list(
                         data,
+                        list_which,
                         to_writer(
                             elem,
                             writer_class,
                             root=root,
                             parent=writer,
-                            annotation_cache=annotation_cache))
+                            annotation_cache=annotation_cache,
+                            schema_node_id=field_proto_data.schema_node_id))
             else:
                 for elem in value:
-                    writer.append_to_list(data, deference_fun(elem))
+                    writer.append_to_list(data, list_which, deference_fun(elem))
 
-            set_value(data)
+            set_value(field_which, data)
         elif field_which == 'void':
-            set_value(None)
+            set_value(field_which, None)
         elif field_which == 'enum':
-            set_value(value._as_str())
+            set_value(field_which, value._as_str())
         else:
             assert field_which in SCALAR_TYPES, field_which
 
-            set_value(deference_fun(value))
+            set_value(field_which, deference_fun(value))
 
     return writer.output()
-
-
-def to_yaml(struct_reader):
-    return to_writer(struct_reader, YamlWriter)
-
-
-def to_json(struct_reader):
-    return to_writer(struct_reader, JsonWriter)
-
-
-class IndexCache():
-    def __init__(self, data):
-        self.data = data
-        self.caches = {}
-
-    def get_index(self, field, value):
-        if field not in self.caches:
-            self.caches[field] = {}
-            for idx, obj in enumerate(self.data[field]):
-                self.caches[field][id(obj)] = idx
-
-        return self.caches[field][id(value)]
-
-
-class YamlReader(BaseReaderWriter):
-    def __init__(self, message, data, parent):
-        super().__init__()
-        self.message = message
-        self.data = data
-        self.objects = {}
-        self.index_cache = IndexCache(self.data)
-        self.parent = parent
-
-    def get_index(self, field, value):
-        return self.index_cache.get_index(field, value)
-
-    def reference_value(self, annotation_type, value, root_reader,
-                        parent_reader):
-        if annotation_type.type == 'root':
-            return root_reader.get_index(annotation_type.field, value)
-        elif annotation_type.type == 'rootValue':
-            return root_reader.objects[annotation_type.field].get_index(value)
-        else:
-            assert annotation_type.type == 'parent'
-            return self.get_parent(annotation_type.depth).get_index(
-                annotation_type.field, value)
-
-
-class JsonIndexCache():
-    def __init__(self, data):
-        self.data = data
-        self.caches = {}
-
-    def get_index(self, field, value):
-        if field not in self.caches:
-            self.caches[field] = {}
-            for idx, obj in enumerate(self.data[field]):
-                self.caches[field][obj['_id']] = idx
-
-        return self.caches[field][value['_id']]
-
-
-class JsonReader(BaseReaderWriter):
-    def __init__(self, message, data, parent):
-        super().__init__()
-        self.message = message
-        self.data = data
-        self.objects = {}
-        self.index_cache = JsonIndexCache(self.data)
-        self.parent = parent
-
-    def get_index(self, field, value):
-        return self.index_cache.get_index(field, value)
-
-    def reference_value(self, annotation_type, value, root_reader,
-                        parent_reader):
-        if annotation_type.type == 'root':
-            return root_reader.get_index(annotation_type.field, value)
-        elif annotation_type.type == 'rootValue':
-            return root_reader.objects[annotation_type.field].get_index(value)
-        else:
-            assert annotation_type.type == 'parent'
-            return self.get_parent(annotation_type.depth).get_index(
-                annotation_type.field, value)
 
 
 def from_reader(message,
@@ -477,7 +160,8 @@ def from_reader(message,
                 reader_class,
                 root=None,
                 parent=None,
-                annotation_cache=None):
+                annotation_cache=None,
+                schema_node_id=None):
     reader = reader_class(message, data, parent)
     if root is None:
         root = reader
@@ -486,11 +170,12 @@ def from_reader(message,
         annotation_cache = AnnotationCache()
 
     schema = message.schema
-    schema_node_id = schema.node.id
+    if schema_node_id is None:
+        schema_node_id = schema.node.id
 
     field_cache = root.get_field_cache(annotation_cache, schema, schema_node_id)
 
-    fields, defered_fields, union_field = field_cache.get_reader_fields(data.keys())
+    fields, defered_fields, union_field = field_cache.get_reader_fields(reader.keys())
 
     for key, annotation_value in defered_fields.items():
         reader.objects[key] = init_implementation(annotation_value)
@@ -502,16 +187,16 @@ def from_reader(message,
 
         which = field.which
         if which == 'group':
-            keys = list(data[key].keys())
+            keys = list(reader.get_field_keys(key))
             assert len(keys) == 1, keys
             inner_key = keys[0]
             builder = getattr(message, key)
-            field_data = data[key][inner_key]
+            field_data = reader.get_inner_field(key, inner_key)
             key = inner_key
             field_proto_data = field.get_group_proto(inner_key)
         else:
             builder = message
-            field_data = data[key]
+            field_data = reader.get_field(key)
             field_proto_data = field.get_field_proto()
 
         if field_proto_data.hide_field:
@@ -522,7 +207,6 @@ def from_reader(message,
         else:
             reference_fun = lambda value: value
 
-        field_type = field_proto_data.field_type
         field_which = field_proto_data.field_which
         if field_which == 'struct':
             builder.init(key)
@@ -532,11 +216,11 @@ def from_reader(message,
                 reader_class=reader_class,
                 root=root,
                 parent=reader,
-                annotation_cache=annotation_cache)
+                annotation_cache=annotation_cache,
+                schema_node_id=field_proto_data.schema_node_id)
         elif field_which == 'list':
             list_builder = builder.init(key, len(field_data))
-            list_type = field_type.list.elementType
-            list_which = list_type.which()
+            list_which = field_proto_data.list_which
 
             if list_which == 'struct':
                 for elem_builder, elem in zip(list_builder, field_data):
@@ -546,7 +230,8 @@ def from_reader(message,
                         reader_class=reader_class,
                         root=root,
                         parent=reader,
-                        annotation_cache=annotation_cache)
+                        annotation_cache=annotation_cache,
+                        schema_node_id=field_proto_data.schema_node_id)
             else:
                 for idx, elem in enumerate(field_data):
                     list_builder[idx] = reference_fun(elem)
@@ -562,11 +247,3 @@ def from_reader(message,
 
     for field in defered_fields:
         reader.objects[field].write_message(message, field)
-
-
-def from_yaml(message, data):
-    from_reader(message, data, YamlReader)
-
-
-def from_json(message, data):
-    from_reader(message, data, JsonReader)

--- a/fpga_interchange/converters.py
+++ b/fpga_interchange/converters.py
@@ -1,5 +1,6 @@
 from fpga_interchange.annotations import AnnotationCache
 
+
 def dereference_value(annotation_type, value, root):
     if annotation_type.type == 'root':
         return getattr(root, annotation_type.field)[value]
@@ -17,7 +18,7 @@ class Enumerator():
         index = self.map.get(value, None)
         if index is None:
             self.values.append(value)
-            return len(self.values)-1
+            return len(self.values) - 1
         else:
             return index
 
@@ -33,6 +34,7 @@ def init_implementation(annotation_value):
         return Enumerator()
     else:
         raise NotImplementedError()
+
 
 def to_yaml(struct_reader, root=None, annotation_cache=None):
     if root is None:
@@ -69,7 +71,8 @@ def to_yaml(struct_reader, root=None, annotation_cache=None):
         deference_fun = None
         hide_field = False
         for annotation in field_proto.annotations:
-            _, annotation_value = annotation_cache.get_annotation_value(annotation)
+            _, annotation_value = annotation_cache.get_annotation_value(
+                annotation)
             if annotation_cache.is_reference_annotation(annotation):
                 assert deference_fun is None
                 deference_fun = lambda value: dereference_value(annotation_value, value, root)
@@ -108,23 +111,24 @@ def to_yaml(struct_reader, root=None, annotation_cache=None):
             set_value(value._as_str())
         else:
             assert field_which in [
-                   'bool',
-                   'int8',
-                   'int16',
-                   'int32',
-                   'int64',
-                   'uint8',
-                   'uint16',
-                   'uint32',
-                   'uint64',
-                   'float32',
-                   'float64',
-                   'text',
-                    ], field_which
+                'bool',
+                'int8',
+                'int16',
+                'int32',
+                'int64',
+                'uint8',
+                'uint16',
+                'uint32',
+                'uint64',
+                'float32',
+                'float64',
+                'text',
+            ], field_which
 
             set_value(deference_fun(value))
 
     return out
+
 
 def reference_value(annotation_type, value, root):
     if annotation_type.type == 'root':
@@ -132,6 +136,7 @@ def reference_value(annotation_type, value, root):
     else:
         assert annotation_type.type == 'parent'
         raise NotImplementedError()
+
 
 def from_yaml(message, data, root=None, annotation_cache=None):
     obj = [data, {}]
@@ -161,7 +166,8 @@ def from_yaml(message, data, root=None, annotation_cache=None):
             continue
 
         for annotation in field.proto.annotations:
-            _, annotation_value = annotation_cache.get_annotation_value(annotation)
+            _, annotation_value = annotation_cache.get_annotation_value(
+                annotation)
             if annotation_cache.is_implementation_annotation(annotation):
                 if annotation_value.hide:
                     obj[1][key] = init_implementation(annotation_value)
@@ -192,7 +198,8 @@ def from_yaml(message, data, root=None, annotation_cache=None):
         reference_fun = None
         hide_field = False
         for annotation in field_proto.annotations:
-            _, annotation_value = annotation_cache.get_annotation_value(annotation)
+            _, annotation_value = annotation_cache.get_annotation_value(
+                annotation)
             if annotation_cache.is_reference_annotation(annotation):
                 assert reference_fun is None
                 reference_fun = lambda value: reference_value(annotation_value, value, root)
@@ -211,7 +218,8 @@ def from_yaml(message, data, root=None, annotation_cache=None):
         field_which = field_type.which()
         if field_which == 'struct':
             builder.init(key)
-            from_yaml(getattr(builder, key), field_data, root, annotation_cache)
+            from_yaml(
+                getattr(builder, key), field_data, root, annotation_cache)
         elif field_which == 'list':
             list_builder = builder.init(key, len(field_data))
             list_type = field_type.list.elementType
@@ -230,19 +238,19 @@ def from_yaml(message, data, root=None, annotation_cache=None):
             setattr(builder, key, field_data)
         else:
             assert field_which in [
-                   'bool',
-                   'int8',
-                   'int16',
-                   'int32',
-                   'int64',
-                   'uint8',
-                   'uint16',
-                   'uint32',
-                   'uint64',
-                   'float32',
-                   'float64',
-                   'text',
-                    ], field_which
+                'bool',
+                'int8',
+                'int16',
+                'int32',
+                'int64',
+                'uint8',
+                'uint16',
+                'uint32',
+                'uint64',
+                'float32',
+                'float64',
+                'text',
+            ], field_which
 
             setattr(builder, key, reference_fun(field_data))
 

--- a/fpga_interchange/converters.py
+++ b/fpga_interchange/converters.py
@@ -1,0 +1,250 @@
+from fpga_interchange.annotations import AnnotationCache
+
+def dereference_value(annotation_type, value, root):
+    if annotation_type.type == 'root':
+        return getattr(root, annotation_type.field)[value]
+    else:
+        assert annotation_type.type == 'parent'
+        raise NotImplementedError()
+
+
+class Enumerator():
+    def __init__(self):
+        self.values = []
+        self.map = {}
+
+    def get_index(self, value):
+        index = self.map.get(value, None)
+        if index is None:
+            self.values.append(value)
+            return len(self.values)-1
+        else:
+            return index
+
+    def write_message(self, message, field):
+        list_builder = message.init(field, len(self.values))
+
+        for idx, value in enumerate(self.values):
+            list_builder[idx] = value
+
+
+def init_implementation(annotation_value):
+    if annotation_value.type == 'enumerator':
+        return Enumerator()
+    else:
+        raise NotImplementedError()
+
+def to_yaml(struct_reader, root=None, annotation_cache=None):
+    if root is None:
+        root = struct_reader
+        annotation_cache = AnnotationCache()
+
+    schema = struct_reader.schema
+
+    out = {}
+
+    fields = set(schema.non_union_fields)
+    if schema.union_fields:
+        fields.add(struct_reader.which())
+
+    for field in schema.fields_list:
+        key = field.proto.name
+        if key not in fields:
+            continue
+
+        which = field.proto.which()
+        if which == 'group':
+            group = getattr(struct_reader, key)
+            inner_key = group.which()
+            value = getattr(group, inner_key)
+
+            set_value = lambda value: out.update({key: {inner_key: value}})
+            field_proto = field.schema.fields[inner_key].proto
+        else:
+            assert which == 'slot', which
+            value = getattr(struct_reader, key)
+            set_value = lambda value: out.update({key: value})
+            field_proto = field.proto
+
+        deference_fun = None
+        hide_field = False
+        for annotation in field_proto.annotations:
+            _, annotation_value = annotation_cache.get_annotation_value(annotation)
+            if annotation_cache.is_reference_annotation(annotation):
+                assert deference_fun is None
+                deference_fun = lambda value: dereference_value(annotation_value, value, root)
+
+            if annotation_cache.is_implementation_annotation(annotation):
+                if annotation_value.hide:
+                    hide_field = True
+
+        if hide_field:
+            continue
+
+        if deference_fun is None:
+            deference_fun = lambda value: value
+
+        field_type = field_proto.slot.type
+
+        field_which = field_type.which()
+        if field_which == 'struct':
+            set_value(to_yaml(value, root, annotation_cache))
+        elif field_which == 'list':
+            list_type = field_type.list.elementType
+            list_which = list_type.which()
+
+            data = []
+            if list_which == 'struct':
+                for elem in value:
+                    data.append(to_yaml(elem, root, annotation_cache))
+            else:
+                for elem in value:
+                    data.append(deference_fun(elem))
+
+            set_value(data)
+        elif field_which == 'void':
+            set_value(None)
+        elif field_which == 'enum':
+            set_value(value._as_str())
+        else:
+            assert field_which in [
+                   'bool',
+                   'int8',
+                   'int16',
+                   'int32',
+                   'int64',
+                   'uint8',
+                   'uint16',
+                   'uint32',
+                   'uint64',
+                   'float32',
+                   'float64',
+                   'text',
+                    ], field_which
+
+            set_value(deference_fun(value))
+
+    return out
+
+def reference_value(annotation_type, value, root):
+    if annotation_type.type == 'root':
+        return root[1][annotation_type.field].get_index(value)
+    else:
+        assert annotation_type.type == 'parent'
+        raise NotImplementedError()
+
+def from_yaml(message, data, root=None, annotation_cache=None):
+    obj = [data, {}]
+    if root is None:
+        root = obj
+        annotation_cache = AnnotationCache()
+
+    schema = message.schema
+
+    fields = set(schema.non_union_fields)
+    defered_fields = set()
+
+    union_field = None
+    for field in schema.union_fields:
+        if field in data:
+            assert union_field is None, (field, union_field)
+            union_field = field
+            fields.add(field)
+
+    for field in schema.fields_list:
+        key = field.proto.name
+        if key not in fields:
+            continue
+
+        which = field.proto.which()
+        if which != 'slot':
+            continue
+
+        for annotation in field.proto.annotations:
+            _, annotation_value = annotation_cache.get_annotation_value(annotation)
+            if annotation_cache.is_implementation_annotation(annotation):
+                if annotation_value.hide:
+                    obj[1][key] = init_implementation(annotation_value)
+                    defered_fields.add(key)
+
+    for field in defered_fields:
+        assert field not in data
+
+    for field in schema.fields_list:
+        key = field.proto.name
+        if key not in fields or key in defered_fields:
+            continue
+
+        which = field.proto.which()
+        if which == 'group':
+            keys = list(data[key].keys())
+            assert len(keys) == 1, keys
+            inner_key = keys[0]
+            builder = getattr(message, key)
+            field_data = data[key][inner_key]
+            key = inner_key
+            field_proto = field.schema.fields[inner_key].proto
+        else:
+            builder = message
+            field_data = data[key]
+            field_proto = field.proto
+
+        reference_fun = None
+        hide_field = False
+        for annotation in field_proto.annotations:
+            _, annotation_value = annotation_cache.get_annotation_value(annotation)
+            if annotation_cache.is_reference_annotation(annotation):
+                assert reference_fun is None
+                reference_fun = lambda value: reference_value(annotation_value, value, root)
+
+            if annotation_cache.is_implementation_annotation(annotation):
+                if annotation_value.hide:
+                    hide_field = True
+
+        if reference_fun is None:
+            reference_fun = lambda value: value
+
+        if hide_field:
+            continue
+
+        field_type = field_proto.slot.type
+        field_which = field_type.which()
+        if field_which == 'struct':
+            builder.init(key)
+            from_yaml(getattr(builder, key), field_data, root, annotation_cache)
+        elif field_which == 'list':
+            list_builder = builder.init(key, len(field_data))
+            list_type = field_type.list.elementType
+            list_which = list_type.which()
+
+            if list_which == 'struct':
+                for elem_builder, elem in zip(list_builder, field_data):
+                    from_yaml(elem_builder, elem, root, annotation_cache)
+            else:
+                for idx, elem in enumerate(field_data):
+                    list_builder[idx] = reference_fun(elem)
+        elif field_which == 'void':
+            assert field_data is None
+            setattr(builder, key, None)
+        elif field_which == 'enum':
+            setattr(builder, key, field_data)
+        else:
+            assert field_which in [
+                   'bool',
+                   'int8',
+                   'int16',
+                   'int32',
+                   'int64',
+                   'uint8',
+                   'uint16',
+                   'uint32',
+                   'uint64',
+                   'float32',
+                   'float64',
+                   'text',
+                    ], field_which
+
+            setattr(builder, key, reference_fun(field_data))
+
+    for field in defered_fields:
+        obj[1][field].write_message(message, field)

--- a/fpga_interchange/field_cache.py
+++ b/fpga_interchange/field_cache.py
@@ -25,8 +25,10 @@ SCALAR_TYPES = [
     'text',
 ]
 
-
-FieldProtoData = namedtuple('FieldProtoData', 'field_proto ref_annotation imp_annotation hide_field field_type field_which list_which schema_node_id')
+FieldProtoData = namedtuple(
+    'FieldProtoData',
+    'field_proto ref_annotation imp_annotation hide_field field_type field_which list_which schema_node_id'
+)
 ReferenceAnnotation = namedtuple('ReferenceAnnotation', 'type field depth')
 
 
@@ -38,10 +40,8 @@ def make_reference_annotation(annotation_value):
     if type == 'parent':
         depth = annotation_value.depth
 
-    return ReferenceAnnotation(
-            type=type,
-            field=field,
-            depth=depth)
+    return ReferenceAnnotation(type=type, field=field, depth=depth)
+
 
 def make_field_proto(annotation_cache, schema_node_id, field_idx, field_proto):
     field_type = field_proto.slot.type
@@ -72,14 +72,14 @@ def make_field_proto(annotation_cache, schema_node_id, field_idx, field_proto):
         schema_node_id = field_type.struct.typeId
 
     return FieldProtoData(
-            field_proto=field_proto,
-            ref_annotation=ref_annotation,
-            imp_annotation=imp_annotation,
-            hide_field=hide_field,
-            field_type=field_type,
-            field_which=field_which,
-            list_which=list_which,
-            schema_node_id=schema_node_id)
+        field_proto=field_proto,
+        ref_annotation=ref_annotation,
+        imp_annotation=imp_annotation,
+        hide_field=hide_field,
+        field_type=field_type,
+        field_which=field_which,
+        list_which=list_which,
+        schema_node_id=schema_node_id)
 
 
 class FieldData():
@@ -97,11 +97,11 @@ class FieldData():
         else:
             assert self.which == 'slot', self.which
             self.field_proto = make_field_proto(
-                    annotation_cache=self.field_cache.annotation_cache,
-                    schema_node_id=self.field_cache.schema_node_id,
-                    field_idx=field_index,
-                    field_proto=field_proto,
-                    )
+                annotation_cache=self.field_cache.annotation_cache,
+                schema_node_id=self.field_cache.schema_node_id,
+                field_idx=field_index,
+                field_proto=field_proto,
+            )
             self.group_protos = None
 
     def get_field_proto(self):
@@ -112,11 +112,11 @@ class FieldData():
         if group_proto is None:
             group_proto = self.field.schema.fields[inner_key].proto
             self.group_protos[inner_key] = make_field_proto(
-                    annotation_cache=self.field_cache.annotation_cache,
-                    schema_node_id=self.field_cache.schema_node_id,
-                    field_idx=self.field_index,
-                    field_proto=group_proto,
-                    )
+                annotation_cache=self.field_cache.annotation_cache,
+                schema_node_id=self.field_cache.schema_node_id,
+                field_idx=self.field_index,
+                field_proto=group_proto,
+            )
 
         return self.group_protos[inner_key]
 

--- a/fpga_interchange/field_cache.py
+++ b/fpga_interchange/field_cache.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+from collections import namedtuple
+
+SCALAR_TYPES = [
+    'bool',
+    'int8',
+    'int16',
+    'int32',
+    'int64',
+    'uint8',
+    'uint16',
+    'uint32',
+    'uint64',
+    'float32',
+    'float64',
+    'text',
+]
+
+
+FieldProtoData = namedtuple('FieldProtoData', 'field_proto ref_annotation imp_annotation hide_field field_type field_which list_which schema_node_id')
+ReferenceAnnotation = namedtuple('ReferenceAnnotation', 'type field depth')
+
+
+def make_reference_annotation(annotation_value):
+    type = annotation_value.type
+    field = annotation_value.field
+    depth = None
+
+    if type == 'parent':
+        depth = annotation_value.depth
+
+    return ReferenceAnnotation(
+            type=type,
+            field=field,
+            depth=depth)
+
+def make_field_proto(annotation_cache, schema_node_id, field_idx, field_proto):
+    field_type = field_proto.slot.type
+    field_which = field_type.which()
+
+    ref_annotation = None
+    imp_annotation = None
+    hide_field = False
+    for annotation_idx, annotation in enumerate(field_proto.annotations):
+        _, annotation_value = annotation_cache.get_annotation_value(
+            schema_node_id, field_idx, annotation_idx, annotation)
+        if annotation_cache.is_reference_annotation(annotation):
+            assert ref_annotation is None
+            ref_annotation = make_reference_annotation(annotation_value)
+
+        if annotation_cache.is_implementation_annotation(annotation):
+            assert imp_annotation is None
+            imp_annotation = annotation_value
+            hide_field = imp_annotation.hide
+
+    list_which = None
+    schema_node_id = None
+    if field_which == 'list':
+        list_which = field_type.list.elementType.which()
+        if list_which == 'struct':
+            schema_node_id = field_type.list.elementType.struct.typeId
+    elif field_which == 'struct':
+        schema_node_id = field_type.struct.typeId
+
+    return FieldProtoData(
+            field_proto=field_proto,
+            ref_annotation=ref_annotation,
+            imp_annotation=imp_annotation,
+            hide_field=hide_field,
+            field_type=field_type,
+            field_which=field_which,
+            list_which=list_which,
+            schema_node_id=schema_node_id)
+
+
+class FieldData():
+    def __init__(self, field_cache, field_index, field):
+        self.field_cache = field_cache
+        self.field_index = field_index
+        self.field = field
+        field_proto = field.proto
+        self.key = field_proto.name
+        self.which = field_proto.which()
+
+        if self.which == 'group':
+            self.field_proto = None
+            self.group_protos = {}
+        else:
+            assert self.which == 'slot', self.which
+            self.field_proto = make_field_proto(
+                    annotation_cache=self.field_cache.annotation_cache,
+                    schema_node_id=self.field_cache.schema_node_id,
+                    field_idx=field_index,
+                    field_proto=field_proto,
+                    )
+            self.group_protos = None
+
+    def get_field_proto(self):
+        return self.field_proto
+
+    def get_group_proto(self, inner_key):
+        group_proto = self.group_protos.get(inner_key, None)
+        if group_proto is None:
+            group_proto = self.field.schema.fields[inner_key].proto
+            self.group_protos[inner_key] = make_field_proto(
+                    annotation_cache=self.field_cache.annotation_cache,
+                    schema_node_id=self.field_cache.schema_node_id,
+                    field_idx=self.field_index,
+                    field_proto=group_proto,
+                    )
+
+        return self.group_protos[inner_key]
+
+
+class FieldCache():
+    def __init__(self, annotation_cache, schema):
+        self.annotation_cache = annotation_cache
+        self.schema = schema
+        self.schema_node_id = schema.node.id
+        self.has_union_fields = bool(schema.union_fields)
+        self.field_data = {}
+        self.base_fields = set(schema.non_union_fields)
+        self.union_fields = set(schema.union_fields)
+        self.fields_list = []
+
+        for idx, field in enumerate(schema.fields_list):
+            self.fields_list.append(FieldData(self, idx, field))
+
+    def fields(self, struct_reader):
+        if self.has_union_fields:
+            fields = set(self.base_fields)
+            fields.add(struct_reader.which())
+            return fields
+        else:
+            return self.base_fields
+
+    def get_reader_fields(self, input_fields):
+        fields = set(self.base_fields)
+        defered_fields = {}
+
+        union_field = None
+        for field in self.union_fields:
+            if field in input_fields:
+                assert union_field is None, (field, union_field)
+                union_field = field
+                fields.add(field)
+
+        for field_data in self.fields_list:
+            key = field_data.key
+            if key not in fields:
+                continue
+
+            which = field_data.which
+            if which != 'slot':
+                continue
+
+            if field_data.field_proto.imp_annotation is not None:
+                defered_fields[key] = field_data.field_proto.imp_annotation
+
+        return fields, defered_fields, union_field

--- a/fpga_interchange/interchange_capnp.py
+++ b/fpga_interchange/interchange_capnp.py
@@ -68,6 +68,7 @@ NO_TRAVERSAL_LIMIT = 2**63 - 1
 
 NESTING_LIMIT = 256
 
+
 def read_capnp_file(capnp_schema,
                     f_in,
                     compression_format=DEFAULT_COMPRESSION_TYPE,
@@ -85,10 +86,14 @@ def read_capnp_file(capnp_schema,
         f_comp = gzip.GzipFile(fileobj=f_in, mode='rb')
         if is_packed:
             return capnp_schema.from_bytes_packed(
-                f_comp.read(), traversal_limit_in_words=NO_TRAVERSAL_LIMIT, nesting_limit=NESTING_LIMIT)
+                f_comp.read(),
+                traversal_limit_in_words=NO_TRAVERSAL_LIMIT,
+                nesting_limit=NESTING_LIMIT)
         else:
             return capnp_schema.from_bytes(
-                f_comp.read(), traversal_limit_in_words=NO_TRAVERSAL_LIMIT, nesting_limit=NESTING_LIMIT)
+                f_comp.read(),
+                traversal_limit_in_words=NO_TRAVERSAL_LIMIT,
+                nesting_limit=NESTING_LIMIT)
     else:
         assert compression_format == CompressionFormat.UNCOMPRESSED
         if is_packed:
@@ -851,11 +856,11 @@ class Interchange():
                                compression_format, is_packed)
 
     def read_device_resources_raw(self,
-                              f,
-                              compression_format=DEFAULT_COMPRESSION_TYPE,
-                              is_packed=IS_PACKED):
+                                  f,
+                                  compression_format=DEFAULT_COMPRESSION_TYPE,
+                                  is_packed=IS_PACKED):
         return read_capnp_file(self.device_resources_schema.Device, f,
-                            compression_format, is_packed)
+                               compression_format, is_packed)
 
     def read_device_resources(self,
                               f,

--- a/fpga_interchange/json_support.py
+++ b/fpga_interchange/json_support.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+from fpga_interchange.converters import BaseReaderWriter, to_writer, from_reader
+
+
+class JsonWriter(BaseReaderWriter):
+    def __init__(self, struct_reader, parent):
+        super().__init__()
+        self.out = {}
+        self.struct_reader = struct_reader
+        self.next_id = 0
+        self.obj_id_cache = {}
+        self.parent = parent
+
+    def get_object_with_id(self, field, value):
+        item = self.out[field][value]
+
+        if id(item) not in self.obj_id_cache:
+            self.obj_id_cache[id(item)] = self.next_id
+            self.next_id += 1
+
+        item_id = self.obj_id_cache[id(item)]
+
+        if '_id' not in item:
+            item['_id'] = item_id
+        else:
+            assert item['_id'] == item_id, (
+                item['_id'],
+                item_id,
+            )
+
+        return item
+
+    def dereference_value(self, annotation_type, value, root_writer,
+                          parent_writer):
+        if annotation_type.type == 'root':
+            return root_writer.get_object_with_id(annotation_type.field, value)
+        elif annotation_type.type == 'rootValue':
+            return root_writer.get_field_value(annotation_type.field, value)
+        else:
+            assert annotation_type.type == 'parent'
+            return self.get_parent(annotation_type.depth).get_object_with_id(
+                annotation_type.field, value)
+
+    def set_value(self, key, value_which, value):
+        self.out[key] = value
+
+    def set_value_inner_key(self, key, inner_key, value_which, value):
+        self.out.update({key: {inner_key: value}})
+
+    def make_list(self):
+        return []
+
+    def append_to_list(self, l, value_which, value):
+        l.append(value)
+
+    def output(self):
+        return self.out
+
+
+class JsonIndexCache():
+    def __init__(self, data):
+        self.data = data
+        self.caches = {}
+
+    def get_index(self, field, value):
+        if field not in self.caches:
+            self.caches[field] = {}
+            for idx, obj in enumerate(self.data[field]):
+                self.caches[field][obj['_id']] = idx
+
+        return self.caches[field][value['_id']]
+
+
+class JsonReader(BaseReaderWriter):
+    def __init__(self, message, data, parent):
+        super().__init__()
+        self.message = message
+        self.data = data
+        self.objects = {}
+        self.index_cache = JsonIndexCache(self.data)
+        self.parent = parent
+
+    def get_index(self, field, value):
+        return self.index_cache.get_index(field, value)
+
+    def reference_value(self, annotation_type, value, root_reader,
+                        parent_reader):
+        if annotation_type.type == 'root':
+            return root_reader.get_index(annotation_type.field, value)
+        elif annotation_type.type == 'rootValue':
+            return root_reader.objects[annotation_type.field].get_index(value)
+        else:
+            assert annotation_type.type == 'parent'
+            return self.get_parent(annotation_type.depth).get_index(
+                annotation_type.field, value)
+
+    def keys(self):
+        return self.data.keys()
+
+    def get_field_keys(self, key):
+        return self.data[key].keys()
+
+    def get_inner_field(self, key, inner_key):
+        return self.data[key][inner_key]
+
+    def get_field(self, key):
+        return self.data[key]
+
+
+def to_json(struct_reader):
+    return to_writer(struct_reader, JsonWriter)
+
+
+def from_json(message, data):
+    from_reader(message, data, JsonReader)

--- a/fpga_interchange/json_support.py
+++ b/fpga_interchange/json_support.py
@@ -37,7 +37,7 @@ class JsonWriter(BaseReaderWriter):
                 item_id,
             )
 
-        return item
+        return {'_id': item_id}
 
     def dereference_value(self, annotation_type, value, root_writer,
                           parent_writer):
@@ -75,7 +75,8 @@ class JsonIndexCache():
         if field not in self.caches:
             self.caches[field] = {}
             for idx, obj in enumerate(self.data[field]):
-                self.caches[field][obj['_id']] = idx
+                if '_id' in obj:
+                    self.caches[field][obj['_id']] = idx
 
         return self.caches[field][value['_id']]
 

--- a/fpga_interchange/json_support.py
+++ b/fpga_interchange/json_support.py
@@ -92,6 +92,9 @@ class JsonReader(BaseReaderWriter):
     def get_index(self, field, value):
         return self.index_cache.get_index(field, value)
 
+    def read_scalar(self, field_which, field_data):
+        return field_data
+
     def reference_value(self, annotation_type, value, root_reader,
                         parent_reader):
         if annotation_type.type == 'root':

--- a/fpga_interchange/rapidyaml_support.py
+++ b/fpga_interchange/rapidyaml_support.py
@@ -313,6 +313,25 @@ class RapidYamlReader(BaseReaderWriter):
 
         return self.field_refs[field][target_ref]
 
+    def read_scalar(self, field_which, field_data):
+        if field_which == 'text':
+            return field_data
+        elif field_which == 'bool':
+            if field_data == True:
+                return True
+            elif field_data == False:
+                return False
+            elif field_data == 'true':
+                return True
+            elif field_data == 'false':
+                return False
+            else:
+                assert False, field_data
+        elif field_which == 'float32' and field_which == 'float64':
+            return float(field_data)
+        else:
+            return int(field_data)
+
     def reference_value(self, annotation_type, value, root_reader,
                         parent_reader):
         if annotation_type.type == 'root':

--- a/fpga_interchange/rapidyaml_support.py
+++ b/fpga_interchange/rapidyaml_support.py
@@ -238,16 +238,11 @@ class YamlIndexCache():
         return self.caches[field][id(value)]
 
 
-def decode_value(s):
-    if s == '~' or s == 'null':
-        return None
-    elif s == 'true':
-        return True
-    elif s == 'false':
-        return False
-    else:
+def handle_value(s):
+    if s is None:
         return s
-
+    else:
+        return bytes(s).decode('utf-8')
 
 def get_value(tree, field_id):
     if tree.is_val_ref(field_id):
@@ -271,12 +266,12 @@ def get_value(tree, field_id):
                         YamlReference(
                             bytes(tree.val_ref(value_id)).decode('utf-8')))
                 else:
-                    s = bytes(tree.val(value_id)).decode('utf-8')
-                    out.append(decode_value(s))
+                    s = handle_value(tree.val(value_id))
+                    out.append(s)
             return out
     else:
-        s = bytes(tree.val(field_id)).decode('utf-8')
-        return decode_value(s)
+        s = handle_value(tree.val(field_id))
+        return s
 
 
 class RapidYamlReader(BaseReaderWriter):

--- a/fpga_interchange/rapidyaml_support.py
+++ b/fpga_interchange/rapidyaml_support.py
@@ -244,6 +244,7 @@ def handle_value(s):
     else:
         return bytes(s).decode('utf-8')
 
+
 def get_value(tree, field_id):
     if tree.is_val_ref(field_id):
         return YamlReference(bytes(tree.val_ref(field_id)).decode('utf-8'))

--- a/fpga_interchange/rapidyaml_support.py
+++ b/fpga_interchange/rapidyaml_support.py
@@ -235,20 +235,6 @@ class RapidYamlWriter(BaseReaderWriter):
             return self.id
 
 
-class YamlIndexCache():
-    def __init__(self, data):
-        self.data = data
-        self.caches = {}
-
-    def get_index(self, field, value):
-        if field not in self.caches:
-            self.caches[field] = {}
-            for idx, obj in enumerate(self.data[field]):
-                self.caches[field][id(obj)] = idx
-
-        return self.caches[field][id(value)]
-
-
 def handle_value(s):
     if s is None:
         return s

--- a/fpga_interchange/rapidyaml_support.py
+++ b/fpga_interchange/rapidyaml_support.py
@@ -12,7 +12,6 @@ from fpga_interchange.converters import BaseReaderWriter, to_writer, from_reader
 import ryml
 from ryml import Tree
 
-
 CHECK_TREE = True
 
 
@@ -31,6 +30,7 @@ def mkvalue(v):
     else:
         return str(v)
 
+
 def set_key_val_ref(tree, mkstr, keyval_id, key, ref):
     assert isinstance(ref, YamlReference)
     # FIXME: Bug in RapidYaml requires setting the value to also be the ref
@@ -38,12 +38,14 @@ def set_key_val_ref(tree, mkstr, keyval_id, key, ref):
     tree.to_keyval(keyval_id, mkstr(key), mkstr('*' + ref.ref))
     tree.set_val_ref(keyval_id, ref.ref)
 
+
 def set_val_ref(tree, mkstr, val_id, ref):
     assert isinstance(ref, YamlReference)
     # FIXME: Bug in RapidYaml requires setting the value to also be the ref
     # string.
     tree.to_val(val_id, mkstr('*' + ref.ref))
     tree.set_val_ref(val_id, ref.ref)
+
 
 class RapidYamlWriter(BaseReaderWriter):
     def __init__(self, struct_reader, parent):
@@ -75,7 +77,9 @@ class RapidYamlWriter(BaseReaderWriter):
 
     def make_reference(self, ref_id):
         if self.tree.is_anchor(ref_id):
-            return YamlReference(self.mkstr(bytes(self.tree.val_anchor(ref_id)).decode('utf-8')))
+            return YamlReference(
+                self.mkstr(
+                    bytes(self.tree.val_anchor(ref_id)).decode('utf-8')))
         else:
             ref = self.mkstr('id{:03d}'.format(self.ref_index))
             self.ref_index += 1
@@ -113,7 +117,8 @@ class RapidYamlWriter(BaseReaderWriter):
         if value_which in SCALAR_TYPES:
             keyval_id = self.tree.append_child(self.id)
             self.field_ids[key] = keyval_id
-            self.tree.to_keyval(keyval_id, self.mkstr(key), self.mkstr(mkvalue(value)))
+            self.tree.to_keyval(keyval_id, self.mkstr(key),
+                                self.mkstr(mkvalue(value)))
         elif value_which == 'list':
             list_id = value
             assert self.tree.parent(list_id) == self.id
@@ -147,7 +152,8 @@ class RapidYamlWriter(BaseReaderWriter):
 
         if value_which in SCALAR_TYPES:
             keyval_id = self.tree.append_child(outer_id)
-            self.tree.to_keyval(keyval_id, self.mkstr(inner_key), self.mkstr(mkvalue(value)))
+            self.tree.to_keyval(keyval_id, self.mkstr(inner_key),
+                                self.mkstr(mkvalue(value)))
         elif value_which == 'list':
             list_id = value
             assert self.tree.parent(list_id) == self.id
@@ -160,10 +166,12 @@ class RapidYamlWriter(BaseReaderWriter):
 
         elif value_which == 'void':
             keyval_id = self.tree.append_child(outer_id)
-            self.tree.to_keyval(keyval_id, self.mkstr(inner_key), self.mkstr('null'))
+            self.tree.to_keyval(keyval_id, self.mkstr(inner_key),
+                                self.mkstr('null'))
         elif value_which == 'enum':
             keyval_id = self.tree.append_child(outer_id)
-            self.tree.to_keyval(keyval_id, self.mkstr(inner_key), self.mkstr(value))
+            self.tree.to_keyval(keyval_id, self.mkstr(inner_key),
+                                self.mkstr(value))
         elif value_which == 'struct':
             assert self.tree.parent(value) == self.nursery_id
             assert self.tree.is_map(value)
@@ -259,7 +267,9 @@ def get_value(tree, field_id):
             out = []
             for value_id in ryml.children(tree, field_id):
                 if tree.is_val_ref(value_id):
-                    out.append(YamlReference(bytes(tree.val_ref(value_id)).decode('utf-8')))
+                    out.append(
+                        YamlReference(
+                            bytes(tree.val_ref(value_id)).decode('utf-8')))
                 else:
                     s = bytes(tree.val(value_id)).decode('utf-8')
                     out.append(decode_value(s))
@@ -354,7 +364,7 @@ class RapidYamlReader(BaseReaderWriter):
         outer_id = self.field_ids[key]
         assert self.tree.num_children(outer_id) == 1
         field_id = self.tree.first_child(outer_id)
-        return {bytes(self.tree.key(field_id)).decode('utf-8'):None}.keys()
+        return {bytes(self.tree.key(field_id)).decode('utf-8'): None}.keys()
 
     def get_inner_field(self, key, inner_key):
         self._init_fields()

--- a/fpga_interchange/rapidyaml_support.py
+++ b/fpga_interchange/rapidyaml_support.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+from fpga_interchange.converters import BaseReaderWriter, to_writer, from_reader, SCALAR_TYPES
+import ryml
+from ryml import Tree
+
+
+CHECK_TREE = True
+
+
+class YamlReference():
+    def __init__(self, ref):
+        self.ref = ref
+
+
+def mkvalue(v):
+    if v is True:
+        return 'true'
+    elif v is False:
+        return 'false'
+    elif v is None:
+        return 'null'
+    else:
+        return str(v)
+
+def set_key_val_ref(tree, mkstr, keyval_id, key, ref):
+    assert isinstance(ref, YamlReference)
+    # FIXME: Bug in RapidYaml requires setting the value to also be the ref
+    # string.
+    tree.to_keyval(keyval_id, mkstr(key), mkstr('*' + ref.ref))
+    tree.set_val_ref(keyval_id, ref.ref)
+
+def set_val_ref(tree, mkstr, val_id, ref):
+    assert isinstance(ref, YamlReference)
+    # FIXME: Bug in RapidYaml requires setting the value to also be the ref
+    # string.
+    tree.to_val(val_id, mkstr('*' + ref.ref))
+    tree.set_val_ref(val_id, ref.ref)
+
+class RapidYamlWriter(BaseReaderWriter):
+    def __init__(self, struct_reader, parent):
+        super().__init__()
+
+        if parent is None:
+            self.tree = Tree()
+            self.tree.reserve(16)
+            self.id = self.tree.root_id()
+            self.strings = []
+            self.tree.to_map(self.id)
+            self.nursery_id = self.tree.append_child(self.id)
+            self.tree.to_seq(self.nursery_id)
+        else:
+            self.tree = parent.tree
+            self.nursery_id = parent.nursery_id
+            self.id = self.tree.append_child(self.nursery_id)
+            self.strings = parent.strings
+            self.tree.to_map(self.id)
+
+        self.field_ids = {}
+        self.struct_reader = struct_reader
+        self.parent = parent
+        self.ref_index = 1
+
+    def mkstr(self, s):
+        self.strings.append(s)
+        return self.strings[-1]
+
+    def make_reference(self, ref_id):
+        if self.tree.is_anchor(ref_id):
+            return YamlReference(self.mkstr(bytes(self.tree.val_anchor(ref_id)).decode('utf-8')))
+        else:
+            ref = self.mkstr('id{:03d}'.format(self.ref_index))
+            self.ref_index += 1
+
+            self.tree.set_val_anchor(ref_id, ref)
+            return YamlReference(ref)
+
+    def dereference_value(self, annotation_type, value, root_writer,
+                          parent_writer):
+        if annotation_type.type == 'root':
+            field_id = root_writer.field_ids[annotation_type.field]
+            ref_id = self.tree.child(field_id, value)
+            return root_writer.make_reference(ref_id)
+
+        elif annotation_type.type == 'rootValue':
+            return root_writer.get_field_value(annotation_type.field, value)
+        else:
+            assert annotation_type.type == 'parent'
+            parent = self.get_parent(annotation_type.depth)
+            field_id = parent.field_ids[annotation_type.field]
+            ref_id = self.tree.child(field_id, value)
+
+            assert field_id == self.tree.parent(ref_id)
+            assert self.tree.is_seq(field_id)
+            assert not self.tree.has_key(ref_id)
+
+            return root_writer.make_reference(ref_id)
+
+    def set_value(self, key, value_which, value):
+        if isinstance(value, YamlReference):
+            keyval_id = self.tree.append_child(self.id)
+            set_key_val_ref(self.tree, self.mkstr, keyval_id, key, value)
+            return
+
+        if value_which in SCALAR_TYPES:
+            keyval_id = self.tree.append_child(self.id)
+            self.field_ids[key] = keyval_id
+            self.tree.to_keyval(keyval_id, self.mkstr(key), self.mkstr(mkvalue(value)))
+        elif value_which == 'list':
+            list_id = value
+            assert self.tree.parent(list_id) == self.id
+            self.field_ids[key] = list_id
+            self.tree._set_key(list_id, self.mkstr(key))
+        elif value_which == 'void':
+            keyval_id = self.tree.append_child(self.id)
+            self.field_ids[key] = keyval_id
+            self.tree.to_keyval(keyval_id, self.mkstr(key), self.mkstr('null'))
+        elif value_which == 'enum':
+            keyval_id = self.tree.append_child(self.id)
+            self.field_ids[key] = keyval_id
+            self.tree.to_keyval(keyval_id, self.mkstr(key), self.mkstr(value))
+        elif value_which == 'struct':
+            assert self.tree.parent(value) == self.nursery_id
+            assert self.tree.is_map(value)
+            self.tree.move(value, self.id, self.tree.last_child(self.id))
+            self.tree._set_key(value, self.mkstr(key))
+            self.field_ids[key] = value
+        else:
+            assert False, value_which
+
+    def set_value_inner_key(self, key, inner_key, value_which, value):
+        outer_id = self.tree.append_child(self.id)
+        self.tree.to_map(outer_id, self.mkstr(key))
+
+        if isinstance(value, YamlReference):
+            keyval_id = self.tree.append_child(outer_id)
+            set_key_val_ref(self.tree, self.mkstr, keyval_id, inner_key, value)
+            return
+
+        if value_which in SCALAR_TYPES:
+            keyval_id = self.tree.append_child(outer_id)
+            self.tree.to_keyval(keyval_id, self.mkstr(inner_key), self.mkstr(mkvalue(value)))
+        elif value_which == 'list':
+            list_id = value
+            assert self.tree.parent(list_id) == self.id
+            self.tree.move(list_id, outer_id, ryml.NONE)
+            self.tree._set_key(list_id, self.mkstr(inner_key))
+
+            assert self.tree.parent(list_id) == outer_id
+            assert self.tree.num_children(outer_id) == 1
+            assert self.tree.first_child(outer_id) == list_id
+
+        elif value_which == 'void':
+            keyval_id = self.tree.append_child(outer_id)
+            self.tree.to_keyval(keyval_id, self.mkstr(inner_key), self.mkstr('null'))
+        elif value_which == 'enum':
+            keyval_id = self.tree.append_child(outer_id)
+            self.tree.to_keyval(keyval_id, self.mkstr(inner_key), self.mkstr(value))
+        elif value_which == 'struct':
+            assert self.tree.parent(value) == self.nursery_id
+            assert self.tree.is_map(value)
+
+            self.tree.move(value, outer_id, ryml.NONE)
+            self.tree._set_key(value, self.mkstr(inner_key))
+
+            assert self.tree.parent(value) == outer_id
+            assert self.tree.num_children(outer_id) == 1
+            assert self.tree.first_child(outer_id) == value
+        else:
+            assert False, value_which
+
+    def make_list(self):
+        list_id = self.tree.append_child(self.id)
+        self.tree.to_seq(list_id)
+        return list_id
+
+    def append_to_list(self, list_id, value_which, value):
+        if isinstance(value, YamlReference):
+            val_id = self.tree.append_child(list_id)
+            set_val_ref(self.tree, self.mkstr, val_id, value)
+            return
+
+        if value_which == 'struct':
+            assert self.tree.parent(value) == self.nursery_id
+            assert self.tree.is_map(value)
+
+            self.tree.move(value, list_id, self.tree.last_child(list_id))
+
+            assert self.tree.parent(value) == list_id
+        else:
+            assert value_which in SCALAR_TYPES
+            val_id = self.tree.append_child(list_id)
+            self.tree.to_val(val_id, self.mkstr(mkvalue(value)))
+
+    def output(self):
+        if self.parent is None:
+            if CHECK_TREE:
+                seen_nodes = set()
+                for node, il in ryml.walk(self.tree):
+                    assert node not in seen_nodes, (node, il)
+                    seen_nodes.add(node)
+
+            assert self.tree.num_children(self.nursery_id) == 0
+            self.tree.remove(self.nursery_id)
+
+            return self.strings, self.tree
+        else:
+            return self.id
+
+
+class YamlIndexCache():
+    def __init__(self, data):
+        self.data = data
+        self.caches = {}
+
+    def get_index(self, field, value):
+        if field not in self.caches:
+            self.caches[field] = {}
+            for idx, obj in enumerate(self.data[field]):
+                self.caches[field][id(obj)] = idx
+
+        return self.caches[field][id(value)]
+
+
+def decode_value(s):
+    if s == '~' or s == 'null':
+        return None
+    elif s == 'true':
+        return True
+    elif s == 'false':
+        return False
+    else:
+        return s
+
+
+def get_value(tree, field_id):
+    if tree.is_val_ref(field_id):
+        return YamlReference(bytes(tree.val_ref(field_id)).decode('utf-8'))
+
+    if tree.is_map(field_id):
+        return field_id
+    elif tree.is_seq(field_id):
+        value_id = tree.first_child(field_id)
+        if value_id == ryml.NONE:
+            return []
+
+        assert not tree.is_seq(value_id)
+        if tree.is_map(value_id):
+            return list(ryml.children(tree, field_id))
+        else:
+            out = []
+            for value_id in ryml.children(tree, field_id):
+                if tree.is_val_ref(value_id):
+                    out.append(YamlReference(bytes(tree.val_ref(value_id)).decode('utf-8')))
+                else:
+                    s = bytes(tree.val(value_id)).decode('utf-8')
+                    out.append(decode_value(s))
+            return out
+    else:
+        s = bytes(tree.val(field_id)).decode('utf-8')
+        return decode_value(s)
+
+
+class RapidYamlReader(BaseReaderWriter):
+    def __init__(self, message, data, parent):
+        super().__init__()
+
+        self.parent = parent
+        if self.parent is None:
+            self.tree = data
+            self.id = self.tree.root_id()
+        else:
+            self.tree = parent.tree
+            self.id = data
+
+        self.field_ids = {}
+        self.field_refs = {}
+        self.objects = {}
+
+        self.message = message
+
+    def _init_fields(self):
+        if len(self.field_ids) > 0:
+            return
+
+        assert self.tree.is_map(self.id)
+
+        for field_id in ryml.children(self.tree, self.id):
+            field_key = bytes(self.tree.key(field_id)).decode('utf-8')
+
+            assert field_key not in self.field_ids
+            self.field_ids[field_key] = field_id
+
+    def find_ref_index(self, field, target_ref):
+        self._init_fields()
+
+        if field not in self.field_refs:
+            field_id = self.field_ids[field]
+            self.field_refs[field] = {}
+            for idx, value_id in enumerate(ryml.children(self.tree, field_id)):
+                if self.tree.is_anchor(value_id):
+                    ref = bytes(self.tree.val_anchor(value_id)).decode('utf-8')
+                    assert ref not in self.field_refs[field]
+                    self.field_refs[field][ref] = idx
+
+        return self.field_refs[field][target_ref]
+
+    def reference_value(self, annotation_type, value, root_reader,
+                        parent_reader):
+        if annotation_type.type == 'root':
+            assert isinstance(value, YamlReference)
+            return root_reader.find_ref_index(annotation_type.field, value.ref)
+        elif annotation_type.type == 'rootValue':
+            return root_reader.objects[annotation_type.field].get_index(value)
+        else:
+            assert annotation_type.type == 'parent'
+            assert isinstance(value, YamlReference)
+            return self.get_parent(annotation_type.depth).find_ref_index(
+                annotation_type.field, value.ref)
+
+    def keys(self):
+        self._init_fields()
+        return self.field_ids.keys()
+
+    def get_field_keys(self, key):
+        self._init_fields()
+        outer_id = self.field_ids[key]
+        assert self.tree.num_children(outer_id) == 1
+        field_id = self.tree.first_child(outer_id)
+        return {bytes(self.tree.key(field_id)).decode('utf-8'):None}.keys()
+
+    def get_inner_field(self, key, inner_key):
+        self._init_fields()
+        outer_id = self.field_ids[key]
+        assert self.tree.num_children(outer_id) == 1
+        field_id = self.tree.first_child(outer_id)
+
+        return get_value(self.tree, field_id)
+
+    def get_field(self, key):
+        self._init_fields()
+        field_id = self.field_ids[key]
+
+        return get_value(self.tree, field_id)
+
+
+def to_rapidyaml(struct_reader):
+    return to_writer(struct_reader, RapidYamlWriter)
+
+
+def from_rapidyaml(message, data):
+    from_reader(message, data, RapidYamlReader)

--- a/fpga_interchange/yaml_support.py
+++ b/fpga_interchange/yaml_support.py
@@ -71,6 +71,9 @@ class YamlReader(BaseReaderWriter):
     def get_index(self, field, value):
         return self.index_cache.get_index(field, value)
 
+    def read_scalar(self, field_which, field_data):
+        return field_data
+
     def reference_value(self, annotation_type, value, root_reader,
                         parent_reader):
         if annotation_type.type == 'root':

--- a/fpga_interchange/yaml_support.py
+++ b/fpga_interchange/yaml_support.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+from fpga_interchange.converters import BaseReaderWriter, to_writer, from_reader
+
+
+class YamlWriter(BaseReaderWriter):
+    def __init__(self, struct_reader, parent):
+        super().__init__()
+        self.out = {}
+        self.struct_reader = struct_reader
+        self.parent = parent
+
+    def dereference_value(self, annotation_type, value, root_writer,
+                          parent_writer):
+        if annotation_type.type == 'root':
+            return root_writer.out[annotation_type.field][value]
+        elif annotation_type.type == 'rootValue':
+            return root_writer.get_field_value(annotation_type.field, value)
+        else:
+            assert annotation_type.type == 'parent'
+            return self.get_parent(
+                annotation_type.depth).out[annotation_type.field][value]
+
+    def set_value(self, key, value_which, value):
+        self.out[key] = value
+
+    def set_value_inner_key(self, key, inner_key, value_which, value):
+        self.out.update({key: {inner_key: value}})
+
+    def make_list(self):
+        return []
+
+    def append_to_list(self, l, value_which, value):
+        l.append(value)
+
+    def output(self):
+        return self.out
+
+
+class YamlIndexCache():
+    def __init__(self, data):
+        self.data = data
+        self.caches = {}
+
+    def get_index(self, field, value):
+        if field not in self.caches:
+            self.caches[field] = {}
+            for idx, obj in enumerate(self.data[field]):
+                self.caches[field][id(obj)] = idx
+
+        return self.caches[field][id(value)]
+
+
+class YamlReader(BaseReaderWriter):
+    def __init__(self, message, data, parent):
+        super().__init__()
+        self.message = message
+        self.data = data
+        self.objects = {}
+        self.index_cache = YamlIndexCache(self.data)
+        self.parent = parent
+
+    def get_index(self, field, value):
+        return self.index_cache.get_index(field, value)
+
+    def reference_value(self, annotation_type, value, root_reader,
+                        parent_reader):
+        if annotation_type.type == 'root':
+            return root_reader.get_index(annotation_type.field, value)
+        elif annotation_type.type == 'rootValue':
+            return root_reader.objects[annotation_type.field].get_index(value)
+        else:
+            assert annotation_type.type == 'parent'
+            return self.get_parent(annotation_type.depth).get_index(
+                annotation_type.field, value)
+
+    def keys(self):
+        return self.data.keys()
+
+    def get_field_keys(self, key):
+        return self.data[key].keys()
+
+    def get_inner_field(self, key, inner_key):
+        return self.data[key][inner_key]
+
+    def get_field(self, key):
+        return self.data[key]
+
+
+def to_yaml(struct_reader):
+    return to_writer(struct_reader, YamlWriter)
+
+
+def from_yaml(message, data):
+    from_reader(message, data, YamlReader)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 pytest
 git+https://github.com/capnproto/pycapnp.git
+ninja
 pyyaml --global-option='--with-libyaml'
 yapf==0.24.0
+git+https://github.com/litghost/rapidyaml.git@fixup_python_packaging#egg=rapidyaml&subdirectory=api/python
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+psutil
 git+https://github.com/capnproto/pycapnp.git
 ninja
 pyyaml --global-option='--with-libyaml'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pytest
+git+https://github.com/capnproto/pycapnp.git
+pyyaml --global-option='--with-libyaml'
 yapf==0.24.0
 -e .

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     python_requires=">=3.7",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=["pycapnp"],
+    install_requires=["pycapnp", "rapidyaml"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: ISC License",

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -26,10 +26,12 @@ from example_netlist import example_logical_netlist, example_physical_netlist
 import pytest
 import psutil
 
+# Set to true to have round_trip_X write files to disk for inspection.
+OUTPUT_FILES = False
+
 
 def check_mem():
     vmem = psutil.virtual_memory()
-    print(vmem)
     return vmem.total < (8 * 1024 * 1024 * 1024)
 
 
@@ -38,8 +40,9 @@ class TestConverterRoundTrip(unittest.TestCase):
         value = to_json(in_message)
         json_string = json.dumps(value, indent=2)
 
-        with open(prefix + '_test_json.json', 'w') as f:
-            f.write(json_string)
+        if OUTPUT_FILES:
+            with open(prefix + '_test_json.json', 'w') as f:
+                f.write(json_string)
 
         value_out = json.loads(json_string)
         message = get_module_from_id(in_message.schema.node.id).new_message()
@@ -49,8 +52,9 @@ class TestConverterRoundTrip(unittest.TestCase):
         value2 = to_json(message)
         json_string2 = json.dumps(value2, indent=2)
 
-        with open(prefix + '_test_json2.json', 'w') as f:
-            f.write(json_string2)
+        if OUTPUT_FILES:
+            with open(prefix + '_test_json2.json', 'w') as f:
+                f.write(json_string2)
 
         self.assertTrue(json_string == json_string2)
 
@@ -58,8 +62,9 @@ class TestConverterRoundTrip(unittest.TestCase):
         value = to_yaml(in_message)
         yaml_string = yaml.dump(value, sort_keys=False, Dumper=Dumper)
 
-        with open(prefix + '_test_yaml.yaml', 'w') as f:
-            f.write(yaml_string)
+        if OUTPUT_FILES:
+            with open(prefix + '_test_yaml.yaml', 'w') as f:
+                f.write(yaml_string)
 
         value_out = yaml.load(yaml_string, Loader=SafeLoader)
         message = get_module_from_id(in_message.schema.node.id).new_message()
@@ -69,8 +74,9 @@ class TestConverterRoundTrip(unittest.TestCase):
         value2 = to_yaml(message)
         yaml_string2 = yaml.dump(value2, sort_keys=False, Dumper=Dumper)
 
-        with open(prefix + '_test_yaml2.yaml', 'w') as f:
-            f.write(yaml_string2)
+        if OUTPUT_FILES:
+            with open(prefix + '_test_yaml2.yaml', 'w') as f:
+                f.write(yaml_string2)
 
         self.assertTrue(yaml_string == yaml_string2)
 
@@ -78,8 +84,9 @@ class TestConverterRoundTrip(unittest.TestCase):
         strings, value = to_rapidyaml(in_message)
         yaml_string = ryml.emit(value)
 
-        with open(prefix + '_test_rapidyaml.yaml', 'w') as f:
-            f.write(yaml_string)
+        if OUTPUT_FILES:
+            with open(prefix + '_test_rapidyaml.yaml', 'w') as f:
+                f.write(yaml_string)
 
         value_out = ryml.parse(yaml_string)
         message = get_module_from_id(in_message.schema.node.id).new_message()
@@ -89,8 +96,9 @@ class TestConverterRoundTrip(unittest.TestCase):
         strings, value2 = to_rapidyaml(message)
         yaml_string2 = ryml.emit(value2)
 
-        with open(prefix + '_test_rapidyaml2.yaml', 'w') as f:
-            f.write(yaml_string2)
+        if OUTPUT_FILES:
+            with open(prefix + '_test_rapidyaml2.yaml', 'w') as f:
+                f.write(yaml_string2)
 
         self.assertTrue(yaml_string == yaml_string2)
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -28,7 +28,7 @@ import psutil
 
 
 def check_mem():
-    return psutil.virtual_memory().total < 7*1024*1024
+    return psutil.virtual_memory().total < 7 * 1024 * 1024
 
 
 class TestConverterRoundTrip(unittest.TestCase):

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -34,9 +34,12 @@ def check_mem():
 
 
 class TestConverterRoundTrip(unittest.TestCase):
-    def round_trip_json(self, in_message):
+    def round_trip_json(self, prefix, in_message):
         value = to_json(in_message)
-        json_string = json.dumps(value)
+        json_string = json.dumps(value, indent=2)
+
+        with open(prefix + '_test_json.json', 'w') as f:
+            f.write(json_string)
 
         value_out = json.loads(json_string)
         message = get_module_from_id(in_message.schema.node.id).new_message()
@@ -44,7 +47,10 @@ class TestConverterRoundTrip(unittest.TestCase):
         compare_capnp(self, in_message, message)
 
         value2 = to_json(message)
-        json_string2 = json.dumps(value2)
+        json_string2 = json.dumps(value2, indent=2)
+
+        with open(prefix + '_test_json2.json', 'w') as f:
+            f.write(json_string2)
 
         self.assertTrue(json_string == json_string2)
 
@@ -69,6 +75,7 @@ class TestConverterRoundTrip(unittest.TestCase):
         self.assertTrue(yaml_string == yaml_string2)
 
     def round_trip_rapidyaml(self, prefix, in_message):
+        return
         strings, value = to_rapidyaml(in_message)
         yaml_string = ryml.emit(value)
 
@@ -95,7 +102,7 @@ class TestConverterRoundTrip(unittest.TestCase):
             schema_directory=os.environ['INTERCHANGE_SCHEMA_PATH'])
         netlist_capnp = logical_netlist.convert_to_capnp(interchange)
 
-        self.round_trip_json(netlist_capnp)
+        self.round_trip_json('log', netlist_capnp)
 
     def test_physical_netlist_json(self):
         phys_netlist = example_physical_netlist()
@@ -104,7 +111,7 @@ class TestConverterRoundTrip(unittest.TestCase):
             schema_directory=os.environ['INTERCHANGE_SCHEMA_PATH'])
         netlist_capnp = phys_netlist.convert_to_capnp(interchange)
 
-        self.round_trip_json(netlist_capnp)
+        self.round_trip_json('phys', netlist_capnp)
 
     @pytest.mark.skipif(check_mem(), reason='This test needs ~7-8 GB of RAM')
     def test_device_json(self):
@@ -118,7 +125,7 @@ class TestConverterRoundTrip(unittest.TestCase):
                              phys_netlist.part + '.device'), 'rb') as f:
             dev_message = interchange.read_device_resources_raw(f)
 
-        self.round_trip_json(dev_message)
+        self.round_trip_json('device', dev_message)
 
     def test_logical_netlist_yaml(self):
         logical_netlist = example_logical_netlist()

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -28,7 +28,9 @@ import psutil
 
 
 def check_mem():
-    return psutil.virtual_memory().total < 7 * 1024 * 1024
+    vmem = psutil.virtual_memory()
+    print(vmem)
+    return vmem.total < (6.5 * 1024 * 1024)
 
 
 class TestConverterRoundTrip(unittest.TestCase):

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -23,7 +23,7 @@ import ryml
 from fpga_interchange.capnp_utils import get_module_from_id
 from fpga_interchange.interchange_capnp import Interchange
 from example_netlist import example_logical_netlist, example_physical_netlist
-import pytest.mark.skipif
+import pytest
 import psutil
 
 
@@ -104,7 +104,7 @@ class TestConverterRoundTrip(unittest.TestCase):
 
         self.round_trip_json(netlist_capnp)
 
-    @pytest.mark.skipif(check_mem())
+    @pytest.mark.skipif(check_mem(), reason='This test needs ~7-8 GB of RAM')
     def test_device_json(self):
         phys_netlist = example_physical_netlist()
 
@@ -154,7 +154,7 @@ class TestConverterRoundTrip(unittest.TestCase):
 
         self.round_trip_rapidyaml('phys', netlist_capnp)
 
-    @pytest.mark.skipif(check_mem())
+    @pytest.mark.skipif(check_mem(), reason='This test needs ~7-8 GB of RAM')
     def test_device_rapidyaml(self):
         phys_netlist = example_physical_netlist()
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,0 +1,115 @@
+#/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+import os
+import unittest
+import json
+import yaml
+from yaml import CSafeLoader as SafeLoader, CDumper as Dumper
+
+import fpga_interchange.converters
+from fpga_interchange.capnp_utils import get_module_from_id
+from fpga_interchange.interchange_capnp import Interchange
+from example_netlist import example_logical_netlist, example_physical_netlist
+
+
+class TestConverterRoundTrip(unittest.TestCase):
+    def round_trip_json(self, in_message):
+        value = fpga_interchange.converters.to_yaml(in_message)
+        json_string = json.dumps(value)
+
+        value_out = json.loads(json_string)
+        message = get_module_from_id(in_message.schema.node.id).new_message()
+        fpga_interchange.converters.from_yaml(message, value_out)
+        value2 = fpga_interchange.converters.to_yaml(message)
+        json_string2 = json.dumps(value2)
+
+        value2_out = json.loads(json_string2)
+
+        self.assertTrue(value_out == value2_out)
+
+    def round_trip_yaml(self, in_message):
+        value = fpga_interchange.converters.to_yaml(in_message)
+        yaml_string = yaml.dump(value, Dumper=Dumper)
+
+        value_out = yaml.load(yaml_string, Loader=SafeLoader)
+        message = get_module_from_id(in_message.schema.node.id).new_message()
+        fpga_interchange.converters.from_yaml(message, value_out)
+        value2 = fpga_interchange.converters.to_yaml(message)
+        yaml_string2 = yaml.dump(value2, Dumper=Dumper)
+
+        value2_out = yaml.load(yaml_string2, Loader=SafeLoader)
+
+        self.assertTrue(value_out == value2_out)
+
+    def test_logical_netlist_json(self):
+        logical_netlist = example_logical_netlist()
+
+        interchange = Interchange(
+            schema_directory=os.environ['INTERCHANGE_SCHEMA_PATH'])
+        netlist_capnp = logical_netlist.convert_to_capnp(interchange)
+
+        self.round_trip_json(netlist_capnp)
+
+    def test_physical_netlist_json(self):
+        phys_netlist = example_physical_netlist()
+
+        interchange = Interchange(
+            schema_directory=os.environ['INTERCHANGE_SCHEMA_PATH'])
+        netlist_capnp = phys_netlist.convert_to_capnp(interchange)
+
+        self.round_trip_json(netlist_capnp)
+
+    def test_device_json(self):
+        return
+        phys_netlist = example_physical_netlist()
+
+        interchange = Interchange(
+            schema_directory=os.environ['INTERCHANGE_SCHEMA_PATH'])
+
+        with open(
+                os.path.join(os.environ['DEVICE_RESOURCE_PATH'],
+                             phys_netlist.part + '.device'), 'rb') as f:
+            dev_message = interchange.read_device_resources_raw(f)
+
+        self.round_trip_json(dev_message)
+
+    def test_logical_netlist_yaml(self):
+        logical_netlist = example_logical_netlist()
+
+        interchange = Interchange(
+            schema_directory=os.environ['INTERCHANGE_SCHEMA_PATH'])
+        netlist_capnp = logical_netlist.convert_to_capnp(interchange)
+
+        self.round_trip_yaml(netlist_capnp)
+
+    def test_physical_netlist_yaml(self):
+        phys_netlist = example_physical_netlist()
+
+        interchange = Interchange(
+            schema_directory=os.environ['INTERCHANGE_SCHEMA_PATH'])
+        netlist_capnp = phys_netlist.convert_to_capnp(interchange)
+
+        self.round_trip_yaml(netlist_capnp)
+
+    def test_device_yaml(self):
+        return
+        phys_netlist = example_physical_netlist()
+
+        interchange = Interchange(
+            schema_directory=os.environ['INTERCHANGE_SCHEMA_PATH'])
+
+        with open(
+                os.path.join(os.environ['DEVICE_RESOURCE_PATH'],
+                             phys_netlist.part + '.device'), 'rb') as f:
+            dev_message = interchange.read_device_resources_raw(f)
+
+        self.round_trip_yaml(dev_message)

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -69,6 +69,7 @@ class TestConverterRoundTrip(unittest.TestCase):
         self.round_trip_json(netlist_capnp)
 
     def test_device_json(self):
+        return
         phys_netlist = example_physical_netlist()
 
         interchange = Interchange(
@@ -100,6 +101,7 @@ class TestConverterRoundTrip(unittest.TestCase):
         self.round_trip_yaml(netlist_capnp)
 
     def test_device_yaml(self):
+        return
         phys_netlist = example_physical_netlist()
 
         interchange = Interchange(

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -23,13 +23,13 @@ from example_netlist import example_logical_netlist, example_physical_netlist
 
 class TestConverterRoundTrip(unittest.TestCase):
     def round_trip_json(self, in_message):
-        value = fpga_interchange.converters.to_yaml(in_message)
+        value = fpga_interchange.converters.to_json(in_message)
         json_string = json.dumps(value)
 
         value_out = json.loads(json_string)
         message = get_module_from_id(in_message.schema.node.id).new_message()
-        fpga_interchange.converters.from_yaml(message, value_out)
-        value2 = fpga_interchange.converters.to_yaml(message)
+        fpga_interchange.converters.from_json(message, value_out)
+        value2 = fpga_interchange.converters.to_json(message)
         json_string2 = json.dumps(value2)
 
         value2_out = json.loads(json_string2)
@@ -69,7 +69,6 @@ class TestConverterRoundTrip(unittest.TestCase):
         self.round_trip_json(netlist_capnp)
 
     def test_device_json(self):
-        return
         phys_netlist = example_physical_netlist()
 
         interchange = Interchange(
@@ -101,7 +100,6 @@ class TestConverterRoundTrip(unittest.TestCase):
         self.round_trip_yaml(netlist_capnp)
 
     def test_device_yaml(self):
-        return
         phys_netlist = example_physical_netlist()
 
         interchange = Interchange(

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -30,7 +30,7 @@ import psutil
 def check_mem():
     vmem = psutil.virtual_memory()
     print(vmem)
-    return vmem.total < (6.5 * 1024 * 1024)
+    return vmem.total < (8 * 1024 * 1024 * 1024)
 
 
 class TestConverterRoundTrip(unittest.TestCase):
@@ -75,7 +75,6 @@ class TestConverterRoundTrip(unittest.TestCase):
         self.assertTrue(yaml_string == yaml_string2)
 
     def round_trip_rapidyaml(self, prefix, in_message):
-        return
         strings, value = to_rapidyaml(in_message)
         yaml_string = ryml.emit(value)
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -33,7 +33,7 @@ class TestConverterRoundTrip(unittest.TestCase):
         value_out = json.loads(json_string)
         message = get_module_from_id(in_message.schema.node.id).new_message()
         from_json(message, value_out)
-        self.assertTrue(compare_capnp(self, in_message, message))
+        compare_capnp(self, in_message, message)
 
         value2 = to_json(message)
         json_string2 = json.dumps(value2)
@@ -50,7 +50,7 @@ class TestConverterRoundTrip(unittest.TestCase):
         value_out = yaml.load(yaml_string, Loader=SafeLoader)
         message = get_module_from_id(in_message.schema.node.id).new_message()
         from_yaml(message, value_out)
-        self.assertTrue(compare_capnp(self, in_message, message))
+        compare_capnp(self, in_message, message)
 
         value2 = to_yaml(message)
         yaml_string2 = yaml.dump(value2, sort_keys=False, Dumper=Dumper)
@@ -70,7 +70,7 @@ class TestConverterRoundTrip(unittest.TestCase):
         value_out = ryml.parse(yaml_string)
         message = get_module_from_id(in_message.schema.node.id).new_message()
         from_rapidyaml(message, value_out)
-        self.assertTrue(compare_capnp(self, in_message, message))
+        compare_capnp(self, in_message, message)
 
         strings, value2 = to_rapidyaml(message)
         yaml_string2 = ryml.emit(value2)
@@ -99,7 +99,6 @@ class TestConverterRoundTrip(unittest.TestCase):
         self.round_trip_json(netlist_capnp)
 
     def test_device_json(self):
-        return
         phys_netlist = example_physical_netlist()
 
         interchange = Interchange(
@@ -137,7 +136,6 @@ class TestConverterRoundTrip(unittest.TestCase):
             schema_directory=os.environ['INTERCHANGE_SCHEMA_PATH'])
         netlist_capnp = logical_netlist.convert_to_capnp(interchange)
 
-        self.round_trip_yaml('log', netlist_capnp)
         self.round_trip_rapidyaml('log', netlist_capnp)
 
     def test_physical_netlist_rapidyaml(self):
@@ -147,11 +145,9 @@ class TestConverterRoundTrip(unittest.TestCase):
             schema_directory=os.environ['INTERCHANGE_SCHEMA_PATH'])
         netlist_capnp = phys_netlist.convert_to_capnp(interchange)
 
-        self.round_trip_yaml('phys', netlist_capnp)
         self.round_trip_rapidyaml('phys', netlist_capnp)
 
     def test_device_rapidyaml(self):
-        return
         phys_netlist = example_physical_netlist()
 
         interchange = Interchange(

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -23,6 +23,12 @@ import ryml
 from fpga_interchange.capnp_utils import get_module_from_id
 from fpga_interchange.interchange_capnp import Interchange
 from example_netlist import example_logical_netlist, example_physical_netlist
+import pytest.mark.skipif
+import psutil
+
+
+def check_mem():
+    return psutil.virtual_memory().total < 7*1024*1024
 
 
 class TestConverterRoundTrip(unittest.TestCase):
@@ -98,6 +104,7 @@ class TestConverterRoundTrip(unittest.TestCase):
 
         self.round_trip_json(netlist_capnp)
 
+    @pytest.mark.skipif(check_mem())
     def test_device_json(self):
         phys_netlist = example_physical_netlist()
 
@@ -147,6 +154,7 @@ class TestConverterRoundTrip(unittest.TestCase):
 
         self.round_trip_rapidyaml('phys', netlist_capnp)
 
+    @pytest.mark.skipif(check_mem())
     def test_device_rapidyaml(self):
         phys_netlist = example_physical_netlist()
 


### PR DESCRIPTION
This is an initial attempt at using capnp annotations to enable automated textual format conversions. I've implemented a prototype that converts to/from capnp, YAML, and JSON, all as defined by the capnp schema.

Remaining work:
 - [x] See if a straight forward abstraction is available that would enable XML
 - [x] Add cross reference annotations for YAML and XML to enable index cross references instead of indices
 - [x] Investigate performance, present data, and determine if the current performance is adequate.
 - [x] Add comments