### PR TITLE
Update schema path now that schema has it's own repository.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,10 @@ jobs:
     - name: Get and build tools
       run: |
         make env
-        git clone -b interchange https://github.com/Xilinx/RapidWright.git $GITHUB_WORKSPACE/env/RapidWright
+        git clone https://github.com/Xilinx/RapidWright.git $GITHUB_WORKSPACE/env/RapidWright
         make -C "$GITHUB_WORKSPACE/env/RapidWright" update_jars
         git clone https://github.com/capnproto/capnproto-java.git $GITHUB_WORKSPACE/env/capnproto-java
+        git clone https://github.com/SymbiFlow/fpga-interchange-schema.git $GITHUB_WORKSPACE/env/fpga-interchange-schema
 
     - name: Test
       run: ./.github/workflows/test.sh

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -10,7 +10,7 @@ pushd "$GITHUB_WORKSPACE/env"
 popd
 
 export CAPNP_PATH="$GITHUB_WORKSPACE/env/capnproto-java/compiler/src/main/schema/"
-export INTERCHANGE_SCHEMA_PATH="$GITHUB_WORKSPACE/env/RapidWright/interchange"
+export INTERCHANGE_SCHEMA_PATH="$GITHUB_WORKSPACE/env/fpga-interchange-schema/interchange"
 export DEVICE_RESOURCE_PATH="$GITHUB_WORKSPACE/env"
 
 make test-py

--- a/fpga_interchange/convert.py
+++ b/fpga_interchange/convert.py
@@ -16,17 +16,49 @@ formats, and selecting subsets of the schemas where possible.
 """
 import argparse
 import json
-import ryml
-import yaml
-from yaml import CSafeLoader as SafeLoader, CDumper as Dumper
+
+# Treat Rapidyaml and PyYAML as optional dependencies.
+try:
+    import ryml as _ryml
+    from fpga_interchange.rapidyaml_support import to_rapidyaml, from_rapidyaml
+    RAPIDYAML_INSTALLED = True
+except ImportError as e:
+    RAPIDYAML_IMPORT_ERROR = e
+    RAPIDYAML_INSTALLED = False
+
+try:
+    import yaml as _yaml
+    from yaml import CSafeLoader as _SafeLoader, CDumper as _Dumper
+    PYYAML_INSTALLED = True
+except ImportError as e:
+    PYYAML_IMPORT_ERROR = e
+    PYYAML_INSTALLED = False
 
 from fpga_interchange.interchange_capnp import Interchange, read_capnp_file, write_capnp_file
 from fpga_interchange.json_support import to_json, from_json
-from fpga_interchange.rapidyaml_support import to_rapidyaml, from_rapidyaml
 from fpga_interchange.yaml_support import to_yaml, from_yaml
 
 SCHEMAS = ('device', 'logical', 'physical')
 FORMATS = ('json', 'yaml', 'capnp', 'pyyaml')
+
+
+def get_ryml():
+    if RAPIDYAML_INSTALLED:
+        return _ryml
+    else:
+        # TODO: https://github.com/SymbiFlow/python-fpga-interchange/issues/11
+        raise RuntimeError(
+            'Rapidyaml failed import, "yaml" support not available.\n\nImport error:\n{}\n\nInstall with "pip install git+https://github.com/litghost/rapidyaml.git@fixup_python_packaging#egg=rapidyaml&subdirectory=api/python"'
+            .format(RAPIDYAML_IMPORT_ERROR))
+
+
+def get_pyyaml():
+    if PYYAML_INSTALLED:
+        return _yaml, _SafeLoader, _Dumper
+    else:
+        raise RuntimeError(
+            'PyYAML failed import, "pyyaml" support not available.\n\nImport error:\n{}\n\nInstall with "pip install pyyaml"'
+            .format(PYYAML_IMPORT_ERROR))
 
 
 def follow_path(schema_root, path):
@@ -45,10 +77,12 @@ def read_format_to_message(message, input_format, in_f):
         json_data = json.loads(json_string)
         from_json(message, json_data)
     elif input_format == 'yaml':
+        ryml = get_ryml()
         yaml_string = in_f.read().decode('utf-8')
         yaml_tree = ryml.parse(yaml_string)
         from_rapidyaml(message, yaml_tree)
     elif input_format == 'pyyaml':
+        yaml, SafeLoader, _ = get_pyyaml()
         yaml_string = in_f.read().decode('utf-8')
         yaml_data = yaml.load(yaml_string, Loader=SafeLoader)
         from_yaml(message, yaml_data)
@@ -94,11 +128,15 @@ def write_format(message, output_format, out_f):
         json_string = json.dumps(json_data, indent=2)
         out_f.write(json_string.encode('utf-8'))
     elif output_format == 'yaml':
+        ryml = get_ryml()
+
         message = message.as_reader()
         strings, yaml_tree = to_rapidyaml(message)
         yaml_string = ryml.emit(yaml_tree)
         out_f.write(yaml_string.encode('utf-8'))
     elif output_format == 'pyyaml':
+        yaml, _, Dumper = get_pyyaml()
+
         message = message.as_reader()
         yaml_data = to_yaml(message)
         yaml_string = yaml.dump(yaml_data, sort_keys=False, Dumper=Dumper)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pytest
 psutil
 git+https://github.com/capnproto/pycapnp.git
 ninja
-pyyaml --global-option='--with-libyaml'
+pyyaml
 yapf==0.24.0
 # TODO: https://github.com/SymbiFlow/python-fpga-interchange/issues/11
 git+https://github.com/litghost/rapidyaml.git@fixup_python_packaging#egg=rapidyaml&subdirectory=api/python

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     python_requires=">=3.7",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=["pycapnp", "rapidyaml", "python-sat"],
+    install_requires=["pycapnp", "python-sat"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: ISC License",


### PR DESCRIPTION
I've also relaxed the dependency on PyYAML and Rapidyaml as optional features.  `fpga_interchange.convert` will generate an error if the user requests support and it isn't loaded.