### PR TITLE
Add local site inverter data, along with some constant network meta.

### DIFF
--- a/fpga_interchange/chip_info.py
+++ b/fpga_interchange/chip_info.py
@@ -56,6 +56,10 @@ class BelInfo():
         # Index into CellMapPOD::cell_bel_pin_map
         self.pin_map = []
 
+        # Index into ports/types/wires if this BEL has inverting site pips.
+        self.non_inverting_pin = -1
+        self.inverting_pin = -1
+
     def field_label(self, label_prefix, field):
         prefix = '{}.site{}.{}.{}'.format(label_prefix, self.site, self.name,
                                           field)
@@ -98,6 +102,12 @@ class BelInfo():
         bba.u8(self.lut_element)
 
         bba.ref(self.field_label(label_prefix, 'pin_map'))
+
+        bba.u8(self.non_inverting_pin)
+        bba.u8(self.inverting_pin)
+
+        # Pad to nearest 32-bit alignment
+        bba.u16(0)
 
 
 class BelPort():
@@ -675,6 +685,8 @@ class Constants():
         self.gnd_net_name = ''
         self.vcc_net_name = ''
 
+        self.best_constant_net = ''
+
     def append_children_bba(self, bba, label_prefix):
         pass
 
@@ -696,6 +708,8 @@ class Constants():
         bba.str_id(self.gnd_net_name)
         bba.str_id(self.vcc_net_name)
 
+        bba.str_id(self.best_constant_net)
+
 
 class ChipInfo():
     def __init__(self):
@@ -703,7 +717,7 @@ class ChipInfo():
         self.generator = ''
 
         # Note: Increment by 1 this whenever schema changes.
-        self.version = 3
+        self.version = 4
         self.width = 0
         self.height = 0
 

--- a/fpga_interchange/nextpnr.py
+++ b/fpga_interchange/nextpnr.py
@@ -56,11 +56,14 @@ class BbaWriter():
             print('str |{}| {}'.format(s, comment), file=self.f)
 
     def str_id(self, s):
-        index = self.const_ids.get_index(s)
+        if s == ('', ):
+            index = self.const_ids.get_index('')
+        else:
+            index = self.const_ids.get_index(s)
 
-        # Pretty weird to see an empty string here, fail and make sure that
-        # this was the intention.
-        assert index > 0, s
+            # Pretty weird to see an empty string here, fail and make sure that
+            # this was the intention.
+            assert index > 0, s
 
         self.u32(index)
 


### PR DESCRIPTION
Two important new constant network changes:
 - Site ports are now marked with their signal type, e.g.
   signal/gnd/vcc.  This is so that the site router can determine if a
   site port can be used to route a specific net.
 - Best constant net name is now available.