### PR TITLE
nexus: Add stub device_config.yaml

### DIFF
--- a/test_data/nexus_device_config.yaml
+++ b/test_data/nexus_device_config.yaml
@@ -1,0 +1,7 @@
+# Which BEL names are global buffers for nextpnr?
+global_buffers: []
+# How should nextpnr lump BELs during analytic placement?
+buckets:
+- bucket: LUTS
+  cells:
+    - LUT4


### PR DESCRIPTION
Currently the only bel/cell being fully exported are LUTs so that's all this rather unexciting config has for now. But it should be enough to set up build scripts in nextpnr for nexus support.