### PR TITLE
Set default parameters on logical netlists from Yosys JSON.

### DIFF
--- a/fpga_interchange/device_resources.py
+++ b/fpga_interchange/device_resources.py
@@ -690,6 +690,7 @@ class DeviceResources():
 
         self.tile_wire_index_to_node_index = None
         self.parameter_definitions = None
+        self.parameters_for_cell = None
 
     def build_node_index(self):
         """ Build node index for looking up wires to nodes. """
@@ -912,12 +913,18 @@ class DeviceResources():
     def init_parameter_definitions(self):
         assert self.parameter_definitions is None
         self.parameter_definitions = {}
+        self.parameters_for_cell = {}
 
         for cell_parameters in self.device_resource_capnp.parameterDefs.cells:
             cell_type = self.strs[cell_parameters.cellType]
 
+            cell_type not in self.parameters_for_cell
+            self.parameters_for_cell[cell_type] = set()
+
             for parameter in cell_parameters.parameters:
                 name = self.strs[parameter.name]
+
+                self.parameters_for_cell[cell_type].add(name)
 
                 key = (cell_type, name)
 
@@ -950,7 +957,7 @@ class DeviceResources():
         """ Return ParameterDefinition class if parameter exists, else None.
 
         Arguments:
-            cell_type (str) - Cell type to get parameter defintion for.
+            cell_type (str) - Cell type to get parameter definition for.
             parameter_name (str) - Parameter name to get definition.
 
         Returns:
@@ -965,3 +972,28 @@ class DeviceResources():
 
         return self.parameter_definitions.get((cell_type, parameter_name),
                                               None)
+
+    def add_default_parameters(self, cell_type, property_map):
+        """ Add default parameters to property_map for cell_type supplied.
+
+        If parameter is not already set, sets that parameter to its default
+        value.
+
+        Arguments:
+            cell_type (str) - Cell type to get default parameters for.
+            property_map (dict-like of str to str) - Property map for cell.
+
+        """
+        if self.parameter_definitions is None:
+            self.init_parameter_definitions()
+
+        if cell_type not in self.parameters_for_cell:
+            return
+
+        for parameter_name in self.parameters_for_cell[cell_type]:
+            if parameter_name in property_map:
+                continue
+
+            key = (cell_type, parameter_name)
+            property_map[parameter_name] = self.parameter_definitions[
+                key].default_value

--- a/fpga_interchange/yosys_json.py
+++ b/fpga_interchange/yosys_json.py
@@ -332,6 +332,9 @@ def convert_cell(device, module_name, module_data, library, libraries, modules,
 
         convert_parameters(device, cell_name, cell_data['type'], property_map)
 
+        # Set default parameters if not already set from Yosys.
+        device.add_default_parameters(cell_data['type'], property_map)
+
         cell.add_cell_instance(
             name=cell_name,
             cell_name=cell_data['type'],


### PR DESCRIPTION
This is important for some vendor tools (e.g. Vivado) that expect
parameters to have a value even if the value is simply the default.