### PR TITLE
chip_info: Bounds check LUT indices

### DIFF
--- a/fpga_interchange/populate_chip_info.py
+++ b/fpga_interchange/populate_chip_info.py
@@ -174,6 +174,9 @@ class LutElementsEmitter():
 
                 lut_bel.out_pin = bel.outputPin
 
+                assert bel.lowBit < lut.width
+                assert bel.highBit < lut.width
+
                 lut_bel.low_bit = bel.lowBit
                 lut_bel.high_bit = bel.highBit
 


### PR DESCRIPTION
Otherwise the LUT mapper ends up failing in a hard-to-debug way (memory corruption) if you get things wrong.

I'm adding the check here as I presume the lack of assertions and use of `operator[]` instead of `at()` inside the nextpnr LUT mapper code is because LUT manipulation is (currently) on the placement hot path.
