### PR TITLE
Initial FASM generator

### DIFF
--- a/fpga_interchange/chip_info_utils.py
+++ b/fpga_interchange/chip_info_utils.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+
+class LutCell():
+    def __init__(self):
+        self.name = ''
+        self.pins = []
+
+
+class LutBel():
+    def __init__(self):
+        self.name = ''
+        self.pins = []
+        self.low_bit = 0
+        self.high_bit = 0
+        self.out_pin = ''
+
+
+class LutElement():
+    def __init__(self):
+        self.width = 0
+        self.lut_bels = []

--- a/fpga_interchange/constraints/tool.py
+++ b/fpga_interchange/constraints/tool.py
@@ -27,7 +27,7 @@ def make_problem_from_device(device, allowed_sites):
     placement_oracle.add_sites_from_device(device)
 
     placements = []
-    for tile, site, tile_type, site_type, bel in device.yield_bels():
+    for tile, site, tile_type, site_type, bel, bel_type in device.yield_bels():
         if site not in allowed_sites:
             continue
 

--- a/fpga_interchange/device_resources.py
+++ b/fpga_interchange/device_resources.py
@@ -724,6 +724,16 @@ class DeviceResources():
 
         return self.tile_types[tile_type_index]
 
+    def get_tile_name_at_site_name(self, site_name):
+        """ Get Tile name at site name. """
+        assert site_name in self.site_name_to_site
+        sites_dict = self.site_name_to_site[site_name]
+
+        # Get the first site in the dict. Assume all alternative sites are at
+        # the same tile
+        site = list(sites_dict.values())[0]
+        return self.strs[site.tile_name_index]
+
     def bel_pin(self, site_name, site_type, bel, pin):
         """ Return BelPin device resource for BEL pin in site.
 

--- a/fpga_interchange/device_resources.py
+++ b/fpga_interchange/device_resources.py
@@ -891,7 +891,7 @@ class DeviceResources():
 
                     for bel in site_type.bels:
                         yield tile_name, site_name, tile.tile_type, \
-                                site.site_type_name, bel.name
+                                site.site_type_name, bel.name, bel.type
 
     def get_primitive_library(self):
         from fpga_interchange.interchange_capnp import to_logical_netlist

--- a/fpga_interchange/fasm_generator.py
+++ b/fpga_interchange/fasm_generator.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+import argparse
+
+from fpga_interchange.interchange_capnp import Interchange
+from fpga_interchange.fasm_generators.xc7 import XC7FasmGenerator
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+
+    parser.add_argument('--schema_dir', required=True)
+    parser.add_argument('--family', default='xc7')
+    parser.add_argument('device_resources')
+    parser.add_argument('logical_netlist')
+    parser.add_argument('physical_netlist')
+
+    args = parser.parse_args()
+
+    interchange = Interchange(args.schema_dir)
+
+    family_map = {
+        "xc7": XC7FasmGenerator,
+    }
+
+    device_resources = args.device_resources
+    logical_net = args.logical_netlist
+    physical_net = args.physical_netlist
+
+    fasm_generator = family_map[args.family](interchange, device_resources,
+                                             logical_net, physical_net)
+    fasm_generator.output_fasm()
+
+
+if __name__ == "__main__":
+    main()

--- a/fpga_interchange/fasm_generators/generic.py
+++ b/fpga_interchange/fasm_generators/generic.py
@@ -111,7 +111,7 @@ class LutMapper():
         Returns the LUTs physical INIT parameter mapping given the initial logical INIT
         value and the cells' data containing the physical mapping of the input pins.
 
-        It is left to the caller to handle cases of fructured LUTs.
+        It is left to the caller to handle cases of fractured LUTs.
         """
 
         def physical_to_logical_map(lut_bel, bel_pins):

--- a/fpga_interchange/fasm_generators/generic.py
+++ b/fpga_interchange/fasm_generators/generic.py
@@ -9,12 +9,16 @@
 #
 # SPDX-License-Identifier: ISC
 from collections import namedtuple
+from math import log2
 
 from fpga_interchange.route_stitching import flatten_segments
-from fpga_interchange.physical_netlist import PhysicalPip
+from fpga_interchange.physical_netlist import PhysicalPip, PhysicalSitePip
+from fpga_interchange.chip_info_utils import LutCell, LutBel, LutElement
 
 PhysCellInstance = namedtuple(
-    'CellInstance', 'cell_type site_name tile_name sites_in_tile attributes')
+    'CellInstance',
+    'cell_type site_name site_type tile_name tile_type sites_in_tile bel bel_pins attributes'
+)
 
 
 class FasmGenerator():
@@ -34,6 +38,138 @@ class FasmGenerator():
 
         self.routing_pips_features = list()
         self.cells_features = list()
+        self.build_luts_definitions()
+        self.build_log_cells_instances()
+        self.build_phys_cells_instances()
+        self.flatten_nets()
+
+    def flatten_nets(self):
+        self.flattened_nets = dict()
+
+        for net in self.physical_netlist.nets:
+            self.flattened_nets[net.name] = flatten_segments(net.sources +
+                                                             net.stubs)
+
+    def get_tile_info_at_site(self, site_name):
+        tile_name = self.device_resources.get_tile_name_at_site_name(site_name)
+        tile = self.device_resources.tile_name_to_tile[tile_name]
+        tile_type = tile.tile_type
+        sites_in_tile = tile.site_names
+
+        return tile_name, tile_type, sites_in_tile
+
+    def build_luts_definitions(self):
+        """
+        Fills luts definition from the device resources database
+        """
+
+        self.site_lut_elements = dict()
+        self.lut_cells = dict()
+
+        for site_lut_element in self.device_resources.device_resource_capnp.lutDefinitions.lutElements:
+            site = site_lut_element.site
+            self.site_lut_elements[site] = list()
+            for lut in site_lut_element.luts:
+                lut_element = LutElement()
+                self.site_lut_elements[site].append(lut_element)
+
+                lut_element.width = lut.width
+
+                for bel in lut.bels:
+                    lut_bel = LutBel()
+                    lut_element.lut_bels.append(lut_bel)
+
+                    lut_bel.name = bel.name
+                    for pin in bel.inputPins:
+                        lut_bel.pins.append(pin)
+
+                    lut_bel.out_pin = bel.outputPin
+
+                    assert bel.lowBit < lut.width
+                    assert bel.highBit < lut.width
+
+                    lut_bel.low_bit = bel.lowBit
+                    lut_bel.high_bit = bel.highBit
+
+        for lut_cell in self.device_resources.device_resource_capnp.lutDefinitions.lutCells:
+            lut = LutCell()
+            self.lut_cells[lut_cell.cell] = lut
+
+            lut.name = lut_cell.cell
+            for pin in lut_cell.inputPins:
+                lut.pins.append(pin)
+
+    def get_phys_lut_init(self, logical_init_value, cell_data):
+        """
+        Returns the LUTs physical INIT parameter mapping given the initial logical INIT
+        value and the cells' data containing the physical mapping of the input pins.
+
+        It is left to the caller to handle cases of fructured LUTs.
+        """
+
+        def find_lut_bel(lut_elements, bel):
+            """ Returns the LUT Bel definition and the corresponding LUT element. """
+            for lut_element in lut_elements:
+                for lut_bel in lut_element.lut_bels:
+                    if lut_bel.name == bel:
+                        return lut_element, lut_bel
+
+        def physical_to_logical_map(lut_bel, bel_pins):
+            """
+            Returns the physical pin to logical pin LUTs mapping.
+            Unused physical pins are set to None.
+            """
+            phys_to_log = dict()
+
+            for pin in lut_bel.pins:
+                phys_to_log[pin] = None
+
+                for bel_pin in bel_pins:
+                    if bel_pin.bel_pin == pin:
+                        phys_to_log[pin] = bel_pin.cell_pin
+                        break
+
+            return phys_to_log
+
+        cell_type = cell_data.cell_type
+        bel = cell_data.bel
+        bel_pins = cell_data.bel_pins
+        site_type = cell_data.site_type
+
+        assert site_type in self.site_lut_elements, site_type
+        lut_elements = self.site_lut_elements[site_type]
+
+        lut_element, lut_bel = find_lut_bel(lut_elements, bel)
+        lut_cell = self.lut_cells[cell_type]
+
+        bitstring_init = "{value:0{digits}b}".format(
+            value=logical_init_value, digits=lut_bel.high_bit + 1)
+
+        # Invert the string to have the LSB in the beginning
+        logical_lut_init = bitstring_init[::-1]
+        phys_to_log = physical_to_logical_map(lut_bel, bel_pins)
+
+        physical_lut_init = list()
+        for phys_init_index in range(0, lut_element.width):
+            log_init_index = 0
+
+            for phys_port_idx in range(0, int(log2(lut_element.width))):
+                if not phys_init_index & (1 << phys_port_idx):
+                    continue
+
+                if phys_port_idx < len(lut_bel.pins):
+                    log_port = phys_to_log.get(lut_bel.pins[phys_port_idx])
+
+                if log_port is None:
+                    continue
+
+                log_port_idx = lut_cell.pins.index(log_port)
+                log_init_index |= (1 << log_port_idx)
+
+            physical_lut_init.append(logical_lut_init[log_init_index])
+
+        # Generate a string and invert the list, to have MSB in first position
+        return "".join(physical_lut_init[::-1])
 
     def build_log_cells_instances(self):
         """
@@ -62,22 +198,29 @@ class FasmGenerator():
         for placement in self.physical_netlist.placements:
             cell_name = placement.cell_name
             cell_type = placement.cell_type
-            site_name = placement.site
-            tile_name = self.device_resources.get_tile_name_at_site_name(
-                site_name)
-            tile = self.device_resources.tile_name_to_tile[tile_name]
-            sites_in_tile = tile.site_names
 
+            site_name = placement.site
+            site_type = self.physical_netlist.site_instances[site_name]
+
+            tile_name, tile_type, sites_in_tile = self.get_tile_info_at_site(
+                site_name)
+
+            bel = placement.bel
+            bel_pins = placement.pins
             cell_attr = self.logical_cells_instances.get(cell_name, None)
 
             self.physical_cells_instances[cell_name] = PhysCellInstance(
                 cell_type=cell_type,
                 site_name=site_name,
+                site_type=site_type,
                 tile_name=tile_name,
+                tile_type=tile_type,
                 sites_in_tile=sites_in_tile,
+                bel=bel,
+                bel_pins=bel_pins,
                 attributes=cell_attr)
 
-    def fill_pip_features(self, site_thru_features=dict()):
+    def fill_pip_features(self):
         """
         This function generates all features corresponding to the physical routing
         PIPs present in the physical netlist.
@@ -97,9 +240,7 @@ class FasmGenerator():
         site_thru_pips = list()
 
         for net in self.physical_netlist.nets:
-            net_segments = flatten_segments(net.sources + net.stubs)
-
-            for segment in net_segments:
+            for segment in self.flattened_nets[net.name]:
                 if isinstance(segment, PhysicalPip):
                     tile = segment.tile
 
@@ -123,6 +264,24 @@ class FasmGenerator():
                         tile, wire1, wire0))
 
         return site_thru_pips
+
+    def get_routing_bels(self, allowed_routing_bels):
+
+        routing_bels = list()
+
+        for net in self.physical_netlist.nets:
+            for segment in self.flattened_nets[net.name]:
+                if isinstance(segment, PhysicalSitePip):
+                    bel = segment.bel
+                    if bel not in allowed_routing_bels:
+                        continue
+
+                    site = segment.site
+                    pin = segment.pin
+
+                    routing_bels.append((site, bel, pin))
+
+        return routing_bels
 
     def output_fasm(self):
         """

--- a/fpga_interchange/fasm_generators/generic.py
+++ b/fpga_interchange/fasm_generators/generic.py
@@ -48,8 +48,10 @@ class FasmGenerator():
         feature_str = ".".join(feature_parts)
         self.cells_features.add(feature_str)
 
-    def add_pip_feature(self, feature_parts):
-        feature_str = ".".join(feature_parts)
+    def add_pip_feature(self, feature_parts, pip_feature_format):
+        tile, wire0, wire1 = feature_parts
+        feature_str = pip_feature_format.format(
+            tile=tile, wire0=wire0, wire1=wire1)
         self.pips_features.add(feature_str)
 
     def flatten_nets(self):
@@ -229,13 +231,13 @@ class FasmGenerator():
                 bel_pins=bel_pins,
                 attributes=cell_attr)
 
-    def fill_pip_features(self, extra_pip_features):
+    def fill_pip_features(self, pip_feature_format, extra_pip_features):
         """
         This function generates all features corresponding to the physical routing
         PIPs present in the physical netlist.
 
-        At the moment, the convention for the PIPs FASM features is:
-            <TILE_NAME>.<WIRE1>.<WIRE0>
+        The pip_feature_format argument is required to have a dynamic FASM feature
+        formatting, depending on how the specification of the FASM device database.
 
         where:
             TILE_NAME: is the name of the tile the PIP belongs to
@@ -275,7 +277,8 @@ class FasmGenerator():
                         extra_pip_features[tile_type_name].append((tile,
                                                                    wire0))
 
-                    self.add_pip_feature((tile, wire1, wire0))
+                    self.add_pip_feature((tile, wire0, wire1),
+                                         pip_feature_format)
 
         return site_thru_pips
 

--- a/fpga_interchange/fasm_generators/generic.py
+++ b/fpga_interchange/fasm_generators/generic.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+from collections import namedtuple
+
+from fpga_interchange.route_stitching import flatten_segments
+from fpga_interchange.physical_netlist import PhysicalPip
+
+PhysCellInstance = namedtuple(
+    'CellInstance', 'cell_type site_name tile_name sites_in_tile attributes')
+
+
+class FasmGenerator():
+    def __init__(self, interchange, device_resources, log_netlist_file,
+                 phy_netlist_file):
+        with open(device_resources, "rb") as f:
+            self.device_resources = interchange.read_device_resources(f)
+
+        with open(log_netlist_file, "rb") as f:
+            self.logical_netlist = interchange.read_logical_netlist(f)
+
+        with open(phy_netlist_file, "rb") as f:
+            self.physical_netlist = interchange.read_physical_netlist(f)
+
+        self.physical_cells_instances = dict()
+        self.logical_cells_instances = dict()
+
+        self.routing_pips_features = list()
+        self.cells_features = list()
+
+    def build_log_cells_instances(self):
+        """
+        Fills a dictionary with the logical cells with their attribute map
+        """
+
+        lib = self.logical_netlist.libraries["work"]
+        for cell in lib.cells.values():
+            for cell_instance, cell_obj in cell.cell_instances.items():
+
+                cell_name = cell_obj.cell_name
+                cell_attrs = cell_obj.property_map
+
+                assert cell_instance not in self.logical_cells_instances, (
+                    cell_instance, self.logical_cells_instances.keys())
+                self.logical_cells_instances[cell_instance] = cell_attrs
+
+    def build_phys_cells_instances(self):
+        """
+        Fills a dictionary for handy lookups of the placed sites and the corresponding tiles.
+
+        The dictionary contains PhysCellInstance objects which are filled with the attribute
+        map from the logical netlist
+        """
+
+        for placement in self.physical_netlist.placements:
+            cell_name = placement.cell_name
+            cell_type = placement.cell_type
+            site_name = placement.site
+            tile_name = self.device_resources.get_tile_name_at_site_name(
+                site_name)
+            tile = self.device_resources.tile_name_to_tile[tile_name]
+            sites_in_tile = tile.site_names
+
+            cell_attr = self.logical_cells_instances.get(cell_name, None)
+
+            self.physical_cells_instances[cell_name] = PhysCellInstance(
+                cell_type=cell_type,
+                site_name=site_name,
+                tile_name=tile_name,
+                sites_in_tile=sites_in_tile,
+                attributes=cell_attr)
+
+    def fill_pip_features(self, site_thru_features=dict()):
+        """
+        This function generates all features corresponding to the physical routing
+        PIPs present in the physical netlist.
+
+        At the moment, the convention for the PIPs FASM features is:
+            <TILE_NAME>.<WIRE1>.<WIRE0>
+
+        where:
+            TILE_NAME: is the name of the tile the PIP belongs to
+            WIRE0: source PIP wire
+            WIRE1: destination PIP wire
+
+        Returns a list containing pseudo PIPs tuple, to be processed by the caller
+        The list contains (<tile>, <wire0>, <wire1>) tuples.
+        """
+
+        site_thru_pips = list()
+
+        for net in self.physical_netlist.nets:
+            net_segments = flatten_segments(net.sources + net.stubs)
+
+            for segment in net_segments:
+                if isinstance(segment, PhysicalPip):
+                    tile = segment.tile
+
+                    tile_type_index = self.device_resources.tile_name_to_tile[
+                        tile].tile_type_index
+                    tile_type = self.device_resources.get_tile_type(
+                        tile_type_index)
+
+                    wire0 = segment.wire0
+                    wire1 = segment.wire1
+
+                    wire0_id = self.device_resources.string_index[wire0]
+                    wire1_id = self.device_resources.string_index[wire1]
+
+                    pip = tile_type.pip(wire0_id, wire1_id)
+                    if pip.which() == "pseudoCells":
+                        site_thru_pips.append((tile, wire0, wire1))
+                        continue
+
+                    self.routing_pips_features.append("{}.{}.{}".format(
+                        tile, wire1, wire0))
+
+        return site_thru_pips
+
+    def output_fasm(self):
+        """
+        Function to generate and print out the FASM features.
+
+        Needs to be implemented by the children classes.
+        """
+        pass

--- a/fpga_interchange/fasm_generators/xc7.py
+++ b/fpga_interchange/fasm_generators/xc7.py
@@ -335,11 +335,21 @@ class XC7FasmGenerator(FasmGenerator):
             features=["IN_USE", "ZINV_CE"],
             callback=lambda m: "BUFHCE.BUFHCE_X{}Y{}".format(0 if m.group(1) == "L" else 1, m.group(2))
             ))
+        #TODO: Better handle BUFGCTRL route-through depending on the
+        #      used input pin
         site_thru_features.append(
             ExtraFeatures(
-                regex="CLK_BUFG_BUFGCTRL([0-9]+)_I[01]",
+                regex="CLK_BUFG_BUFGCTRL([0-9]+)_I0",
                 features=[
                     "IN_USE", "ZINV_CE0", "ZINV_S0", "IS_IGNORE1_INVERTED"
+                ],
+                callback=
+                lambda m: "BUFGCTRL.BUFGCTRL_X0Y{}".format(m.group(1))))
+        site_thru_features.append(
+            ExtraFeatures(
+                regex="CLK_BUFG_BUFGCTRL([0-9]+)_I1",
+                features=[
+                    "IN_USE", "ZINV_CE1", "ZINV_S1", "IS_IGNORE0_INVERTED"
                 ],
                 callback=
                 lambda m: "BUFGCTRL.BUFGCTRL_X0Y{}".format(m.group(1))))

--- a/fpga_interchange/fasm_generators/xc7.py
+++ b/fpga_interchange/fasm_generators/xc7.py
@@ -24,12 +24,13 @@ Such special cases may include:
 
 """
 import re
-from enum import Enum
 from collections import namedtuple
+from enum import Enum
+from itertools import product
 
-from fpga_interchange.fasm_generators.generic import FasmGenerator
+from fpga_interchange.fasm_generators.generic import FasmGenerator, PhysCellInstance
 from fpga_interchange.route_stitching import flatten_segments
-from fpga_interchange.physical_netlist import PhysicalPip
+from fpga_interchange.physical_netlist import PhysicalPip, Pin
 """
 This is a helper object that is used to find and emit extra features
 that do depend on the usage of specific PIPs or Pseudo PIPs.
@@ -56,6 +57,33 @@ class LutsEnum(Enum):
             raise NotImplementedError
 
 
+def parse_lut_bel(lut_bel):
+    """
+    Perform a regex match with the provided LUT name, to identify in which category
+    the LUT falls into:
+
+    input:
+        lut_name = A5LUT
+
+    output:
+        lut_type = LUT5
+        lut_loc  = A
+    """
+
+    bel_re = re.compile("([ABCD])([56])LUT")
+
+    m = bel_re.match(lut_bel)
+    assert m, lut_bel
+
+    # A, B, C or D
+    lut_loc = m.group(1)
+
+    # LUT5 or LUT6
+    lut_type = "LUT{}".format(m.group(2))
+
+    return lut_loc, lut_type
+
+
 class XC7FasmGenerator(FasmGenerator):
     def handle_ios(self):
         """
@@ -78,7 +106,8 @@ class XC7FasmGenerator(FasmGenerator):
             ]
         }
 
-        iob_sites = ["IOB_Y1", "IOB_Y0"]
+        iob_sites = ["IOB_Y0", "IOB_Y1"]
+        iob_re = re.compile("IOB_X[0-9]+Y([0-9]+)")
 
         for cell_instance, cell_data in self.physical_cells_instances.items():
             if cell_data.cell_type not in allowed_io_types:
@@ -86,81 +115,44 @@ class XC7FasmGenerator(FasmGenerator):
 
             tile_name = cell_data.tile_name
 
-            iob_site_idx = cell_data.sites_in_tile.index(cell_data.site_name)
+            m = iob_re.match(cell_data.site_name)
+            assert m, site_name
 
-            iob_site = iob_sites[
-                iob_site_idx] if "SING" not in tile_name else "IOB_Y0"
+            y_coord = int(m.group(1))
+            if "SING" in tile_name and y_coord % 50 == 0:
+                iob_sites_idx = 0
+            elif "SING" in tile_name and y_coord % 50 == 49:
+                iob_sites_idx = 1
+            else:
+                iob_sites_idx = y_coord % 2
+
+            iob_site = iob_sites[iob_sites_idx]
 
             for feature in allowed_io_types[cell_data.cell_type]:
                 self.add_cell_feature((tile_name, iob_site, feature))
 
     @staticmethod
-    def get_slice_prefix(site_name, tile_type, sites_in_tile):
+    def get_slice_prefix(site_name, tile_type):
         """
         Returns the slice prefix corresponding to the input site name.
         """
 
         slice_sites = {
-            "CLBLL_L": ["SLICEL_X1", "SLICEL_X0"],
-            "CLBLL_R": ["SLICEL_X1", "SLICEL_X0"],
-            "CLBLM_L": ["SLICEL_X1", "SLICEM_X0"],
-            "CLBLM_R": ["SLICEL_X1", "SLICEM_X0"],
+            "CLBLL_L": ["SLICEL_X0", "SLICEL_X1"],
+            "CLBLL_R": ["SLICEL_X0", "SLICEL_X1"],
+            "CLBLM_L": ["SLICEM_X0", "SLICEL_X1"],
+            "CLBLM_R": ["SLICEM_X0", "SLICEL_X1"],
         }
 
-        slice_site_idx = sites_in_tile.index(site_name)
+        slice_re = re.compile("SLICE_X([0-9]+)Y[0-9]+")
+        m = slice_re.match(site_name)
+        assert m, site_name
+
+        slice_site_idx = int(m.group(1)) % 2
         return slice_sites[tile_type][slice_site_idx]
 
-    def handle_luts(self):
-        """
-        This function handles LUTs FASM features generation
-        """
-
-        bel_re = re.compile("([ABCD])([56])LUT")
-
-        luts = dict()
-
-        for cell_instance, cell_data in self.physical_cells_instances.items():
-            if not cell_data.cell_type.startswith("LUT"):
-                continue
-
-            site_name = cell_data.site_name
-            site_type = cell_data.site_type
-
-            tile_name = cell_data.tile_name
-            tile_type = cell_data.tile_type
-            sites_in_tile = cell_data.sites_in_tile
-            slice_site = self.get_slice_prefix(site_name, tile_type,
-                                               sites_in_tile)
-
-            bel = cell_data.bel
-            m = bel_re.match(bel)
-            assert m, bel
-
-            # A, B, C or D
-            lut_loc = m.group(1)
-            lut_name = "{}LUT".format(lut_loc)
-
-            # LUT5 or LUT6
-            lut_type = "LUT{}".format(m.group(2))
-
-            init_param = self.device_resources.get_parameter_definition(
-                cell_data.cell_type, "INIT")
-            init_value = init_param.decode_integer(
-                cell_data.attributes["INIT"])
-
-            phys_lut_init = self.get_phys_lut_init(init_value, cell_data)
-
-            key = (site_name, lut_loc)
-            if key not in luts:
-                luts[key] = {
-                    "data": (tile_name, slice_site, lut_name),
-                    LutsEnum.LUT5: None,
-                    LutsEnum.LUT6: None,
-                }
-
-            luts[key][LutsEnum.from_str(lut_type)] = phys_lut_init
-
-        for lut in luts.values():
+    def add_lut_features(self):
+        for lut in self.luts.values():
             tile_name, slice_site, lut_name = lut["data"]
 
             lut5 = lut[LutsEnum.LUT5]
@@ -180,6 +172,46 @@ class XC7FasmGenerator(FasmGenerator):
 
             self.add_cell_feature((tile_name, slice_site, lut_name,
                                    init_feature))
+
+    def handle_luts(self):
+        """
+        This function handles LUTs FASM features generation
+        """
+
+        self.luts = dict()
+
+        for cell_instance, cell_data in self.physical_cells_instances.items():
+            if not cell_data.cell_type.startswith("LUT"):
+                continue
+
+            site_name = cell_data.site_name
+            site_type = cell_data.site_type
+
+            tile_name = cell_data.tile_name
+            tile_type = cell_data.tile_type
+            slice_site = self.get_slice_prefix(site_name, tile_type)
+
+            bel = cell_data.bel
+            lut_loc, lut_type = parse_lut_bel(bel)
+            lut_name = "{}LUT".format(lut_loc)
+
+            init_param = self.device_resources.get_parameter_definition(
+                cell_data.cell_type, "INIT")
+            init_value = init_param.decode_integer(
+                cell_data.attributes["INIT"])
+
+            phys_lut_init = self.lut_mapper.get_phys_cell_lut_init(
+                init_value, cell_data)
+
+            key = (site_name, lut_loc)
+            if key not in self.luts:
+                self.luts[key] = {
+                    "data": (tile_name, slice_site, lut_name),
+                    LutsEnum.LUT5: None,
+                    LutsEnum.LUT6: None,
+                }
+
+            self.luts[key][LutsEnum.from_str(lut_type)] = phys_lut_init
 
     def handle_slice_ff(self):
         """
@@ -202,9 +234,7 @@ class XC7FasmGenerator(FasmGenerator):
 
             tile_name = cell_data.tile_name
             tile_type = cell_data.tile_type
-            sites_in_tile = cell_data.sites_in_tile
-            slice_site = self.get_slice_prefix(site_name, tile_type,
-                                               sites_in_tile)
+            slice_site = self.get_slice_prefix(site_name, tile_type)
 
             bel = cell_data.bel
 
@@ -226,6 +256,8 @@ class XC7FasmGenerator(FasmGenerator):
                 self.add_cell_feature((tile_name, slice_site, bel, "ZINI"))
 
     def handle_clock_resources(self):
+
+        bufg_re = re.compile("BUFGCTRL_X[0-9]+Y([0-9]+)")
         for cell_instance, cell_data in self.physical_cells_instances.items():
             cell_type = cell_data.cell_type
             if cell_type not in ["BUFG", "BUFGCTRL"]:
@@ -233,7 +265,11 @@ class XC7FasmGenerator(FasmGenerator):
 
             site_name = cell_data.site_name
             site_type = cell_data.site_type
-            site_loc = cell_data.sites_in_tile.index(site_name)
+
+            m = bufg_re.match(cell_data.site_name)
+            assert m, site_name
+
+            site_loc = int(m.group(1)) % 16
             site_prefix = "BUFGCTRL.BUFGCTRL_X0Y{}".format(site_loc)
 
             tile_name = cell_data.tile_name
@@ -243,6 +279,30 @@ class XC7FasmGenerator(FasmGenerator):
             if cell_type == "BUFG":
                 for feature in ["IS_IGNORE1_INVERTED", "ZINV_CE0", "ZINV_S0"]:
                     self.add_cell_feature((tile_name, site_prefix, feature))
+
+    def handle_slice_routing_bels(self):
+        allowed_routing_bels = list()
+
+        used_muxes = ["SRUSEDMUX", "CEUSEDMUX"]
+        allowed_routing_bels.extend(used_muxes)
+
+        for loc in "ABCD":
+            ff_mux = "{}FFMUX".format(loc)
+            ff5_mux = "{}5FFMUX".format(loc)
+            out_mux = "{}OUTMUX".format(loc)
+            allowed_routing_bels.extend([ff_mux, ff5_mux, out_mux])
+
+        routing_bels = self.get_routing_bels(allowed_routing_bels)
+
+        for site, bel, pin in routing_bels:
+            tile_name, tile_type = self.get_tile_info_at_site(site)
+            slice_prefix = self.get_slice_prefix(site, tile_type)
+
+            if bel in used_muxes:
+                if pin not in ["0", "1"]:
+                    self.add_cell_feature((tile_name, slice_prefix, bel))
+            else:
+                self.add_cell_feature((tile_name, slice_prefix, bel, pin))
 
     def handle_site_thru(self, site_thru_pips):
         """
@@ -296,40 +356,86 @@ class XC7FasmGenerator(FasmGenerator):
 
                 break
 
-    def handle_slice_routing_bels(self):
-        allowed_routing_bels = list()
+    def handle_lut_thru(self, lut_thru_pips):
+        for (net_name, site, bel), pin in lut_thru_pips.items():
+            pin_name = pin["pin_name"]
+            is_valid = pin["is_valid"]
 
-        used_muxes = ["SRUSEDMUX", "CEUSEDMUX"]
-        allowed_routing_bels.extend(used_muxes)
+            if not is_valid:
+                continue
 
-        for loc in "ABCD":
-            ff_mux = "{}FFMUX".format(loc)
-            ff5_mux = "{}5FFMUX".format(loc)
-            out_mux = "{}OUTMUX".format(loc)
-            allowed_routing_bels.extend([ff_mux, ff5_mux, out_mux])
+            lut_loc, lut_type = parse_lut_bel(bel)
 
-        routing_bels = self.get_routing_bels(allowed_routing_bels)
+            site_type = list(
+                self.device_resources.site_name_to_site[site].keys())[0]
 
-        for site, bel, pin in routing_bels:
-            tile_name, tile_type, sites_in_tile = self.get_tile_info_at_site(
-                site)
-            slice_prefix = self.get_slice_prefix(site, tile_type,
-                                                 sites_in_tile)
+            lut_key = (site, lut_loc)
+            if lut_key not in self.luts:
+                tile_name, tile_type = self.get_tile_info_at_site(site)
+                slice_site = self.get_slice_prefix(site, tile_type)
+                lut_name = "{}LUT".format(lut_loc)
 
-            if bel in used_muxes:
-                if pin not in ["0", "1"]:
-                    self.add_cell_feature((tile_name, slice_prefix, bel))
-            else:
-                self.add_cell_feature((tile_name, slice_prefix, bel, pin))
+                self.luts[lut_key] = {
+                    "data": (tile_name, slice_site, lut_name),
+                    LutsEnum.LUT5: None,
+                    LutsEnum.LUT6: None,
+                }
 
-    def handle_pips(self):
+            lut_enum = LutsEnum.from_str(lut_type)
+            assert self.luts[lut_key][lut_enum] is None, (net_name, site, bel)
+
+            wire_lut_init = self.lut_mapper.get_phys_wire_lut_init(
+                2, site_type, "LUT1", bel, pin_name)
+            self.luts[lut_key][lut_enum] = wire_lut_init
+
+    def handle_extra_pip_features(self, extra_pip_features):
         """
-        Handles all the FASM features corresponding to PIPs
+        There are some sensitive PIPs and features which mostly deal with clocking resources
+        and require special handling, as without the extra features, the clocking tree configuration
+        migth be incomplete, resulting in unexpected hardware behavior.
 
-        In addition, emits extra features necessary to have the clock
-        resources working properly, as well the emission of site route
-        thru features for pseudo PIPs
+        This function handles all the special extra features corresponding to a restricted class
+        of special PIPs.
         """
+
+        def run_regex_match(extra_feature,
+                            tile,
+                            wire,
+                            extra_wires,
+                            enable_extra_wires=True):
+            """
+            This helper function adds the corresponding extra features based on the callback of
+            the ExtraFeature element and the regex match status.
+
+            It also adds, if enabled, a set of extra wires belonging to the input wire's
+            node, that may require some extra features as well.
+            """
+
+            extra_wires_to_check = ["CLK_BUFG_REBUF_R_CK", "HCLK_CK_BUFHCLK"]
+
+            if any(
+                    wire.startswith(extra_wire) for extra_wire in
+                    extra_wires_to_check) and enable_extra_wires:
+                node_index = self.device_resources.node(tile, wire).node_index
+                wires = self.device_resources.device_resource_capnp.nodes[
+                    node_index].wires
+                for wire_idx in wires:
+                    tile_wire = self.device_resources.device_resource_capnp.wires[
+                        wire_idx]
+                    wire_name = self.device_resources.strs[tile_wire.wire]
+                    tile_name = self.device_resources.strs[tile_wire.tile]
+
+                    extra_wires.add((tile_name, wire_name))
+
+            regex = re.compile(extra_feature.regex)
+            m = regex.match(wire)
+
+            if m:
+                prefix = extra_feature.callback(m)
+
+                for f in extra_feature.features:
+                    f = "{}{}".format(prefix, f)
+                    self.add_cell_feature((tile, f))
 
         # TODO: The FASM database should be reformatted so to have more
         #       regular extra PIP features.
@@ -351,8 +457,18 @@ class XC7FasmGenerator(FasmGenerator):
                 callback=lambda m: m.group(1)))
         regexs.append(
             ExtraFeatures(
+                regex="(HCLK_CMT_CK_BUFHCLK[0-9]+)",
+                features=["_USED"],
+                callback=lambda m: m.group(1)))
+        regexs.append(
+            ExtraFeatures(
                 regex="CLK_BUFG_REBUF_R_CK_(GCLK[0-9]+)_BOT",
-                features=["_ENABLE_BELOW", "_ENABLE_ABOVE"],
+                features=["_ENABLE_ABOVE"],
+                callback=lambda m: m.group(1)))
+        regexs.append(
+            ExtraFeatures(
+                regex="CLK_BUFG_REBUF_R_CK_(GCLK[0-9]+)_TOP",
+                features=["_ENABLE_BELOW"],
                 callback=lambda m: m.group(1)))
         regexs.append(
             ExtraFeatures(
@@ -360,40 +476,71 @@ class XC7FasmGenerator(FasmGenerator):
                 features=[""],
                 callback=lambda m: "ENABLE_BUFFER.{}".format(m.group(1))))
 
+        extra_wires = set()
+        for tile_pips in extra_pip_features.values():
+            for tile, wire in tile_pips:
+                for extra_feature in regexs:
+                    run_regex_match(extra_feature, tile, wire, extra_wires)
+
+        # Handle extra wires
+        exclude_tiles = [
+            "HCLK_L", "HCLK_R", "HCLK_L_BOT_UTURN", "HCLK_R_BOT_UTURN"
+        ]
+        for tile, wire in extra_wires:
+            if any(
+                    tile.startswith(exclude_tile)
+                    for exclude_tile in exclude_tiles):
+                continue
+
+            for extra_feature in regexs:
+                run_regex_match(extra_feature, tile, wire, extra_wires, False)
+
+    def handle_pips(self):
+        """
+        Handles all the FASM features corresponding to PIPs
+
+        In addition, emits extra features necessary to have the clock
+        resources working properly, as well the emission of site route
+        thru features for pseudo PIPs
+        """
+
+        avail_lut_thrus = list()
+        for _, _, _, _, bel, bel_type in self.device_resources.yield_bels():
+            if bel_type in ["LUT5", "LUT6"]:
+                avail_lut_thrus.append(bel)
+
         tile_types = [
             "HCLK_L", "HCLK_R", "HCLK_L_BOT_UTURN", "HCLK_R_BOT_UTURN",
             "HCLK_CMT", "HCLK_CMT_L", "CLK_HROW_TOP_R", "CLK_HROW_BOT_R",
             "CLK_BUFG_REBUF"
         ]
-        extra_features = dict((tile_type, list()) for tile_type in tile_types)
+        extra_pip_features = dict(
+            (tile_type, set()) for tile_type in tile_types)
 
         pip_feature_format = "{tile}.{wire1}.{wire0}"
-        site_thru_pips = self.fill_pip_features(pip_feature_format,
-                                                extra_features)
+        site_thru_pips, lut_thru_pips = self.fill_pip_features(
+            pip_feature_format, extra_pip_features, avail_lut_thrus)
 
-        for tile_type, tile_pips in extra_features.items():
-            for tile, pip in tile_pips:
-                for extra_feature in regexs:
-                    comp_regex = re.compile(extra_feature.regex)
-
-                    m = comp_regex.match(pip)
-
-                    if m:
-                        prefix = extra_feature.callback(m)
-
-                        for f in extra_feature.features:
-                            f = "{}{}".format(prefix, f)
-                            self.add_cell_feature((tile, f))
-
+        self.handle_extra_pip_features(extra_pip_features)
         self.handle_site_thru(site_thru_pips)
+        self.handle_lut_thru(lut_thru_pips)
 
     def output_fasm(self):
-        self.handle_pips()
-        self.handle_slice_routing_bels()
+        # Handling BELs
         self.handle_slice_ff()
         self.handle_ios()
         self.handle_luts()
         self.handle_clock_resources()
+
+        # Handling routing BELs
+        self.handle_slice_routing_bels()
+
+        # Handling PIPs and Route-throughs
+        self.handle_pips()
+
+        # Emit LUT features. This needs to be done at last as
+        # LUT features depend also on LUT route-thru
+        self.add_lut_features()
 
         for cell_feature in sorted(list(self.cells_features)):
             print(cell_feature)

--- a/fpga_interchange/fasm_generators/xc7.py
+++ b/fpga_interchange/fasm_generators/xc7.py
@@ -8,9 +8,26 @@
 # https://opensource.org/licenses/ISC
 #
 # SPDX-License-Identifier: ISC
+import re
+from enum import Enum
+
 from fpga_interchange.fasm_generators.generic import FasmGenerator
 from fpga_interchange.route_stitching import flatten_segments
 from fpga_interchange.physical_netlist import PhysicalPip
+
+
+class LutsEnum(Enum):
+    LUT5 = 0
+    LUT6 = 1
+
+    @classmethod
+    def from_str(cls, label):
+        if label == "LUT5":
+            return cls.LUT5
+        elif label == "LUT6":
+            return cls.LUT6
+        else:
+            raise NotImplementedError
 
 
 class XC7FasmGenerator(FasmGenerator):
@@ -50,6 +67,95 @@ class XC7FasmGenerator(FasmGenerator):
                 self.cells_features.append("{}.{}.{}".format(
                     cell_data.tile_name, iob_site, feature))
 
+    @staticmethod
+    def get_slice_prefix(site_name, tile_type, sites_in_tile):
+        """
+        Returns the slice prefix corresponding to the input site name.
+        """
+
+        slice_sites = {
+            "CLBLL_L": ["SLICEL_X1", "SLICEL_X0"],
+            "CLBLL_R": ["SLICEL_X1", "SLICEL_X0"],
+            "CLBLM_L": ["SLICEL_X1", "SLICEM_X0"],
+            "CLBLM_R": ["SLICEL_X1", "SLICEM_X0"],
+        }
+
+        slice_site_idx = sites_in_tile.index(site_name)
+        return slice_sites[tile_type][slice_site_idx]
+
+    def handle_luts(self):
+        """
+        This function handles LUTs FASM features generation
+        """
+
+        bel_re = re.compile("([ABCD])([56])LUT")
+
+        luts = dict()
+
+        for cell_instance, cell_data in self.physical_cells_instances.items():
+            if not cell_data.cell_type.startswith("LUT"):
+                continue
+
+            site_name = cell_data.site_name
+            site_type = cell_data.site_type
+
+            tile_name = cell_data.tile_name
+            tile_type = cell_data.tile_type
+            sites_in_tile = cell_data.sites_in_tile
+            slice_site = self.get_slice_prefix(site_name, tile_type,
+                                               sites_in_tile)
+
+            bel = cell_data.bel
+            m = bel_re.match(bel)
+            assert m, bel
+
+            # A, B, C or D
+            lut_loc = m.group(1)
+            lut_name = "{}LUT".format(lut_loc)
+
+            # LUT5 or LUT6
+            lut_type = "LUT{}".format(m.group(2))
+
+            init_param = self.device_resources.get_parameter_definition(
+                cell_data.cell_type, "INIT")
+            init_value = init_param.decode_integer(
+                cell_data.attributes["INIT"])
+
+            phys_lut_init = self.get_phys_lut_init(init_value, cell_data)
+
+            key = (site_name, lut_loc)
+            if key not in luts:
+                luts[key] = {
+                    "data": (tile_name, slice_site, lut_name),
+                    LutsEnum.LUT5: None,
+                    LutsEnum.LUT6: None,
+                }
+
+            luts[key][LutsEnum.from_str(lut_type)] = phys_lut_init
+
+        for lut in luts.values():
+            tile_name, slice_site, lut_name = lut["data"]
+
+            lut5 = lut[LutsEnum.LUT5]
+            lut6 = lut[LutsEnum.LUT6]
+
+            if lut5 is not None and lut6 is not None:
+                lut_init = "{}{}".format(lut6[0:32], lut5[32:64])
+            elif lut5 is not None:
+                lut_init = lut5
+            elif lut6 is not None:
+                lut_init = lut6
+            else:
+                assert False
+
+            init_feature = "{}.INIT[{}:0]={}'b{}".format(
+                lut_name,
+                len(lut_init) - 1, len(lut_init), lut_init)
+            lut_feature = "{}.{}.{}".format(tile_name, slice_site,
+                                            init_feature)
+
+            self.cells_features.append(lut_feature)
+
     def handle_site_thru(self, site_thru_pips):
         """
         This function is currently specialized to add very specific features
@@ -75,13 +181,32 @@ class XC7FasmGenerator(FasmGenerator):
             for feature in features:
                 self.cells_features.append("{}.{}".format(tile, feature))
 
-    def output_fasm(self):
-        self.build_log_cells_instances()
-        self.build_phys_cells_instances()
+    def handle_slice_routing_bels(self):
+        allowed_routing_bels = list()
 
+        for loc in "ABCD":
+            ff_mux = "{}FFMUX".format(loc)
+            out_mux = "{}OUTMUX".format(loc)
+            allowed_routing_bels.extend([ff_mux, out_mux])
+
+        routing_bels = self.get_routing_bels(allowed_routing_bels)
+
+        for site, bel, pin in routing_bels:
+            tile_name, tile_type, sites_in_tile = self.get_tile_info_at_site(
+                site)
+            slice_prefix = self.get_slice_prefix(site, tile_type,
+                                                 sites_in_tile)
+
+            routing_bel_feature = "{}.{}.{}.{}".format(tile_name, slice_prefix,
+                                                       bel, pin)
+            self.cells_features.append(routing_bel_feature)
+
+    def output_fasm(self):
         site_thru_pips = self.fill_pip_features()
         self.handle_site_thru(site_thru_pips)
+        self.handle_slice_routing_bels()
         self.handle_ios()
+        self.handle_luts()
 
         for cell_feature in sorted(
                 self.cells_features, key=lambda f: f.split(".")[0]):

--- a/fpga_interchange/fasm_generators/xc7.py
+++ b/fpga_interchange/fasm_generators/xc7.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+from fpga_interchange.fasm_generators.generic import FasmGenerator
+from fpga_interchange.route_stitching import flatten_segments
+from fpga_interchange.physical_netlist import PhysicalPip
+
+
+class XC7FasmGenerator(FasmGenerator):
+    def handle_ios(self):
+        """
+        This function is specialized to add FASM features for the IO buffers
+        in the 7-Series database format.
+        """
+
+        # FIXME: Need to make this dynamic, and find a suitable way to add FASM annotations to the device resources.
+        #        In addition, a reformat of the database might be required to have an easier handling of these
+        #        features.
+        allowed_io_types = {
+            "OBUF": [
+                "LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL_SSTL135_SSTL15.SLEW.SLOW",
+                "LVCMOS33_LVTTL.DRIVE.I12_I16", "PULLTYPE.NONE"
+            ],
+            "IBUF": [
+                "LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL.SLEW.FAST",
+                "LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVDS_25_LVTTL_SSTL135_SSTL15_TMDS_33.IN_ONLY",
+                "LVCMOS25_LVCMOS33_LVTTL.IN", "PULLTYPE.NONE"
+            ]
+        }
+
+        iob_sites = ["IOB_Y1", "IOB_Y0"]
+
+        for cell_instance, cell_data in self.physical_cells_instances.items():
+            if cell_data.cell_type not in allowed_io_types:
+                continue
+
+            iob_site_idx = cell_data.sites_in_tile.index(cell_data.site_name)
+
+            iob_site = iob_sites[
+                iob_site_idx] if "SING" not in cell_data.tile_name else "IOB_Y0"
+
+            for feature in allowed_io_types[cell_data.cell_type]:
+                self.cells_features.append("{}.{}.{}".format(
+                    cell_data.tile_name, iob_site, feature))
+
+    def handle_site_thru(self, site_thru_pips):
+        """
+        This function is currently specialized to add very specific features
+        for pseudo PIPs which need to be enabled to get the correct HW behaviour
+        """
+
+        # FIXME: this information needs to be added as an annotation
+        #        to the device resources
+        wire_to_features_map = {
+            "IOI_OLOGIC0_D1": [
+                "OLOGIC_Y0.OMUX.D1", "OLOGIC_Y0.OQUSED",
+                "OLOGIC_Y0.OSERDES.DATA_RATE_TQ.BUF"
+            ],
+            "IOI_OLOGIC1_D1": [
+                "OLOGIC_Y1.OMUX.D1", "OLOGIC_Y1.OQUSED",
+                "OLOGIC_Y1.OSERDES.DATA_RATE_TQ.BUF"
+            ]
+        }
+
+        for tile, wire0, wire1 in site_thru_pips:
+            features = wire_to_features_map.get(wire0, [])
+
+            for feature in features:
+                self.cells_features.append("{}.{}".format(tile, feature))
+
+    def output_fasm(self):
+        self.build_log_cells_instances()
+        self.build_phys_cells_instances()
+
+        site_thru_pips = self.fill_pip_features()
+        self.handle_site_thru(site_thru_pips)
+        self.handle_ios()
+
+        for cell_feature in sorted(
+                self.cells_features, key=lambda f: f.split(".")[0]):
+            print(cell_feature)
+
+        for routing_pip in sorted(
+                self.routing_pips_features, key=lambda f: f.split(".")[0]):
+            print(routing_pip)

--- a/fpga_interchange/fasm_generators/xc7.py
+++ b/fpga_interchange/fasm_generators/xc7.py
@@ -367,7 +367,9 @@ class XC7FasmGenerator(FasmGenerator):
         ]
         extra_features = dict((tile_type, list()) for tile_type in tile_types)
 
-        site_thru_pips = self.fill_pip_features(extra_features)
+        pip_feature_format = "{tile}.{wire1}.{wire0}"
+        site_thru_pips = self.fill_pip_features(pip_feature_format,
+                                                extra_features)
 
         for tile_type, tile_pips in extra_features.items():
             for tile, pip in tile_pips:

--- a/fpga_interchange/parameter_definitions.py
+++ b/fpga_interchange/parameter_definitions.py
@@ -238,8 +238,8 @@ class ParameterDefinition():
             hex_string = str_value.replace("{}'h".format(self.width), "")
             return int(hex_string, 16)
         elif self.string_format == ParameterFormat.C_BINARY:
-            bin_string = str_value.replace("0b".format(self.width), "")
+            bin_string = str_value.replace("0b", "")
             return int(bin_string, 2)
         elif self.string_format == ParameterFormat.C_HEX:
-            hex_string = str_value.replace("0x".format(self.width), "")
+            hex_string = str_value.replace("0x", "")
             return int(hex_string, 16)

--- a/fpga_interchange/parameter_definitions.py
+++ b/fpga_interchange/parameter_definitions.py
@@ -217,3 +217,29 @@ class ParameterDefinition():
             return '0b{:b}'.format(int_value)
         elif self.string_format == ParameterFormat.C_HEX:
             return '0x{:X}'.format(int_value)
+
+    def decode_integer(self, str_value):
+        assert self.is_integer_like()
+
+        if self.string_format == ParameterFormat.BOOLEAN:
+            if str_value == "FALSE":
+                return 0
+            elif str_value == "TRUE":
+                return 1
+            else:
+                raise ValueError(
+                    'Invalid boolean string value {}'.format(str_value))
+        elif self.string_format == ParameterFormat.INTEGER:
+            return int(str_value)
+        elif self.string_format == ParameterFormat.VERILOG_BINARY:
+            bin_string = str_value.replace("{}'b".format(self.width), "")
+            return int(bin_string, 2)
+        elif self.string_format == ParameterFormat.VERILOG_HEX:
+            hex_string = str_value.replace("{}'h".format(self.width), "")
+            return int(hex_string, 16)
+        elif self.string_format == ParameterFormat.C_BINARY:
+            bin_string = str_value.replace("0b".format(self.width), "")
+            return int(bin_string, 2)
+        elif self.string_format == ParameterFormat.C_HEX:
+            hex_string = str_value.replace("0x".format(self.width), "")
+            return int(hex_string, 16)

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,6 @@ setuptools.setup(
             'fpga_inter_nextpnr_emit=fpga_interchange.nextpnr_emit:main',
             'fpga_inter_patch=fpga_interchange.patch:main',
             'fpga_inter_yosys_json=fpga_interchange.yosys_json:main',
+            'fpga_inter_fasm_generator=fpga_interchange.fasm_generator:main',
         ],
     })


### PR DESCRIPTION
At the moment, we need to still come up with a good enhancement of the schema to support FASM features annotations to be added to the DeviceResources for a more data-driven approach.

With the current initial implementation, FASM features a quite fixed, and, even though they can still be made more data-driven, some specialization may be required to handle different devices families, hence the adoption of a inheritance based generator, such that different families can change the implementation or have more detailed functions to add and deal with some possibly complex FASM annotations.

This initial implementation is able to generate valid FASM outputs for the `const_wire` and `wire` from nextpnr which do work on HW.

This PR was opened mainly to get an early review of the progress.

TODO:
- [ ] Add capability to emit FASM features based on cells attributes
- [x] Initial handling of routing bels
- Handle other cells types:
  - [x] LUTs
  - [x] FF
  - [x] BUFG/BUFH
- [ ] Add tests