### PR TITLE
fpga_interchange: allow 'x' and 'z' special values

### DIFF
--- a/fpga_interchange/yosys_json.py
+++ b/fpga_interchange/yosys_json.py
@@ -19,6 +19,9 @@ from fpga_interchange.logical_netlist import LogicalNetlist, Cell, \
 from fpga_interchange.parameter_definitions import ParameterFormat
 
 
+def is_special_value(value):
+    return value in ['x', 'z']
+
 def is_bus(bits, offset, upto):
     """ Returns true if this port/net is a bus.
 
@@ -142,6 +145,10 @@ def convert_parameters(device, cell, cell_type, property_map):
             # Non-integer like parameters come from yosys as a string, leave
             # them alone.
             property_map[name] = check_trailing_space(property_map[name])
+            continue
+
+        if is_special_value(check_trailing_space(property_map[name])):
+            # 'X' or 'Z' value
             continue
 
         yosys_value = property_map[name]


### PR DESCRIPTION
'x' and 'z' values can appear in JSON emitted by Yosys, for example:
```
        "$auto$simplemap.cc:420:simplemap_dff$1390": {
          "hide_name": 1,
          "type": "FDRE",
          "parameters": {
            "INIT": "x"
          },
```
because `INIT` parameter is treated as `VERILOG_BINARY` the above example will result with conversion error, hence we need to handle these special values for non-string parameters.


Signed-off-by: Jan Kowalewski <jkowalewski@antmicro.com>