### PR TITLE
Enable disabling of route-thru PIPs for BUFGCTRL

### DIFF
--- a/fpga_interchange/nextpnr_emit.py
+++ b/fpga_interchange/nextpnr_emit.py
@@ -44,8 +44,11 @@ def main():
     else:
         global_buffers = []
 
+    disabled_routethroughs = device_config.get('disabled_routethroughs', [])
+
     chip_info = populate_chip_info(device, const_ids, global_buffers,
-                                   device_config['buckets'])
+                                   device_config['buckets'],
+                                   disabled_routethroughs)
 
     with open(os.path.join(args.output_dir, 'chipdb.bba'), 'w') as f:
         bba = BbaWriter(f, const_ids)

--- a/test_data/series7_device_config.yaml
+++ b/test_data/series7_device_config.yaml
@@ -54,3 +54,6 @@ buckets:
    - MUXCY
    - XORCY
    - CARRY4
+# don't route through the following cells
+disabled_routethroughs:
+  - BUFGCTRL


### PR DESCRIPTION
BUFGCTRL route-throughs are currently broken, and need to be disabled.
This stops them from being exported to nextpnr.

Hotfix for the issue discussed in #57