### PR TITLE
fasm: explicit fasm file argument

### DIFF
--- a/fpga_interchange/__init__.py
+++ b/fpga_interchange/__init__.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+
+def get_version():
+    import pkg_resources
+
+    return pkg_resources.get_distribution("python-fpga-interchange").version

--- a/fpga_interchange/fasm_generator.py
+++ b/fpga_interchange/fasm_generator.py
@@ -17,11 +17,16 @@ from fpga_interchange.fasm_generators.xc7 import XC7FasmGenerator
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
 
-    parser.add_argument('--schema_dir', required=True)
-    parser.add_argument('--family', default='xc7')
-    parser.add_argument('device_resources')
-    parser.add_argument('logical_netlist')
-    parser.add_argument('physical_netlist')
+    parser.add_argument(
+        '--schema_dir',
+        required=True,
+        help="Path to the FPGA interchange schemas directory.")
+    parser.add_argument(
+        '--family', required=True, help="Device family. E.g. xc7, xcu, etc.")
+    parser.add_argument('device_resources', help="Device resources file.")
+    parser.add_argument('logical_netlist', help="Logical netlist file.")
+    parser.add_argument('physical_netlist', help="Physical netlist file.")
+    parser.add_argument('fasm_file', help="FASM output file.")
 
     args = parser.parse_args()
 
@@ -34,10 +39,12 @@ def main():
     device_resources = args.device_resources
     logical_net = args.logical_netlist
     physical_net = args.physical_netlist
+    fasm_file = args.fasm_file
 
     fasm_generator = family_map[args.family](interchange, device_resources,
                                              logical_net, physical_net)
-    fasm_generator.output_fasm()
+    fasm_generator.fill_features()
+    fasm_generator.output_fasm(fasm_file)
 
 
 if __name__ == "__main__":

--- a/fpga_interchange/fasm_generators/xc7.py
+++ b/fpga_interchange/fasm_generators/xc7.py
@@ -535,7 +535,7 @@ class XC7FasmGenerator(FasmGenerator):
         self.handle_site_thru(site_thru_pips)
         self.handle_lut_thru(lut_thru_pips)
 
-    def output_fasm(self):
+    def fill_features(self):
         # Handling BELs
         self.handle_slice_ff()
         self.handle_ios()
@@ -551,9 +551,3 @@ class XC7FasmGenerator(FasmGenerator):
         # Emit LUT features. This needs to be done at last as
         # LUT features depend also on LUT route-thru
         self.add_lut_features()
-
-        for cell_feature in sorted(list(self.cells_features)):
-            print(cell_feature)
-
-        for routing_pip in sorted(list(self.pips_features)):
-            print(routing_pip)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="python-fpga-interchange",
-    version="0.0.8",
+    version="0.0.9",
     author="SymbiFlow Authors",
     author_email="symbiflow@lists.librecores.org",
     description="Python library for reading and writing FPGA interchange files",


### PR DESCRIPTION
This commit also:
- slightly changes the way the physical LUT init is generated and fixes a few comments
- adds an origin line to the output FASM file to know which version was used to generate a specific FASM output
