### PR TITLE
yosys_json: Convert macros to blackboxes

### DIFF
--- a/fpga_interchange/yosys_json.py
+++ b/fpga_interchange/yosys_json.py
@@ -472,6 +472,11 @@ def convert_yosys_json(device,
             libraries[lib_name] = Library(lib_name)
 
         prim_cell = primitive_cells[required_cell]
+
+        # Blackbox macro content, we only care about the primitive ports - the macro content is obtained from the chipdb
+        prim_cell.cell_instances.clear()
+        prim_cell.nets.clear()
+
         netlist.libraries[lib_name].add_cell(prim_cell)
 
     return netlist


### PR DESCRIPTION
We don't want to include the macro content in the logical netlist; as at this point macros are blackboxes just like primitives.

The macro expansion is based on data in the chipdb; not the netlist.
