### PR TITLE
WIP: add initial support for BELs chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ env
 *.swp
 *.swo
 *.yaml
+!test_data/*

--- a/fpga_interchange/nextpnr.py
+++ b/fpga_interchange/nextpnr.py
@@ -81,5 +81,5 @@ class BbaWriter():
 
     def check_labels(self):
         refs_and_labels = self.refs & self.labels
-        assert len(refs_and_labels) == len(self.refs)
-        assert len(refs_and_labels) == len(self.labels)
+        assert len(refs_and_labels) == len(self.refs), "{} vs. {}".format(len(refs_and_labels), len(self.refs))
+        assert len(refs_and_labels) == len(self.labels), "{} vs. {}".format(len(refs_and_labels), len(self.labels))

--- a/fpga_interchange/populate_chip_info.py
+++ b/fpga_interchange/populate_chip_info.py
@@ -1838,12 +1838,13 @@ def populate_chip_info(device, constids, device_config):
     bel_chains = {}
     for bel_chain in device.device_resource_capnp.belChainsDefinitions.belChains:
         assert bel_chain.name not in bel_chains.keys()
-        cfgs_present = bel_chain.which() == "coordConfigs"
+        drivers_present = bel_chain.which() == "chainDrivers"
         bel_chains[bel_chain.name] = BelChain(bel_chain.name,
                                             bel_chain.patterns,
                                             bel_chain.sites,
-                                            bel_chain.coordConfigs if cfgs_present else None,
-                                            bel_chain.cells)
+                                            bel_chain.coordConfigs,
+                                            bel_chain.cells,
+                                            bel_chain.chainDrivers if drivers_present else None)
 
         chip_info.bel_chains.append(bel_chains[bel_chain.name])
 

--- a/fpga_interchange/populate_chip_info.py
+++ b/fpga_interchange/populate_chip_info.py
@@ -16,8 +16,8 @@ from fpga_interchange.chip_info import ChipInfo, BelInfo, TileTypeInfo, \
         TileWireRef, CellBelMap, ParameterPins, CellBelPin, ConstraintTag, \
         CellConstraint, ConstraintType, Package, PackagePin, LutCell, \
         LutElement, LutBel, CellParameter, DefaultCellConnections, DefaultCellConnection, \
-        WireType, Macro, MacroNet, MacroPortInst, MacroCellInst, MacroExpansion, MacroParamMapRule, MacroParamRuleType, MacroParameter, GlobalCell, GlobalCellPin
-
+        WireType, Macro, MacroNet, MacroPortInst, MacroCellInst, MacroExpansion, \
+        MacroParamMapRule, MacroParamRuleType, MacroParameter, GlobalCell, GlobalCellPin, BelChain
 from fpga_interchange.constraints.model import Tag, Placement, \
         ImpliesConstraint, RequiresConstraint
 from fpga_interchange.constraint_generator import ConstraintPrototype
@@ -1834,6 +1834,18 @@ def populate_chip_info(device, constids, device_config):
     for lut_element in device.device_resource_capnp.lutDefinitions.lutElements:
         assert lut_element.site not in lut_elements
         lut_elements[lut_element.site] = LutElementsEmitter(lut_element.luts)
+
+    bel_chains = {}
+    for bel_chain in device.device_resource_capnp.belChainsDefinitions.belChains:
+        assert bel_chain.name not in bel_chains.keys()
+        cfgs_present = bel_chain.which() == "coordConfigs"
+        bel_chains[bel_chain.name] = BelChain(bel_chain.name,
+                                            bel_chain.patterns,
+                                            bel_chain.sites,
+                                            bel_chain.coordConfigs if cfgs_present else None,
+                                            bel_chain.cells)
+
+        chip_info.bel_chains.append(bel_chains[bel_chain.name])
 
     for tile_type_index, tile_type in enumerate(
             device.device_resource_capnp.tileTypeList):

--- a/test_data/series7_bel_chains.yaml
+++ b/test_data/series7_bel_chains.yaml
@@ -1,15 +1,26 @@
 belChains:
-  - name: carryChain
-    patterns: 
-      - {source: {type: "CARRY4", port: "CO[3]"}, sink: {type: "CARRY4", port: "CI"}}
-    sites:
-      - SLICEL
-      - SLICEM
+- name: carryChain
+  patterns:
+    - {source: {type: "CARRY4", port: "CO[3]"}, sink: {type: "CARRY4", port: "CI"}}
+  sites:
+    - SLICEL
+    - SLICEM
+  cells:
+    - CARRY4
+  chainDrivers: # Place driver cell of S port to a proper BEL
+  - ports:
+    - name: S[0]
+      bel: AFF
+    - name: S[1]
+      bel: BFF
+    - name: S[2]
+      bel: CFF
+    - name: S[3]
+      bel: DFF
     cells:
-      - CARRY4
-    chainDrivers: # Place driver cell of S port to a proper BEL
-      - {ports: ["S[0]", "S[1]", "S[2]", "S[3]"],
-         bels: ["LUT6", "LUT_OR_MEM6"]}
-    coordConfigs:
-      - {coord: y, step: -1} # Default
-      - {coord: y, step: -2} # When crossing clock region
+      - FDRE
+      - FDSE
+      - FDCE
+  coordConfigs:
+    - {coord: y, step: -1} # Default
+    - {coord: y, step: -2} # When crossing clock region

--- a/test_data/series7_bel_chains.yaml
+++ b/test_data/series7_bel_chains.yaml
@@ -6,9 +6,10 @@ belChains:
       - SLICEL
       - SLICEM
     cells:
-      - XORCY
-      - MUXCY
       - CARRY4
+    chainDrivers: # Place driver cell of S port to a proper BEL
+      - {ports: ["S[0]", "S[1]", "S[2]", "S[3]"],
+         bels: ["LUT6", "LUT_OR_MEM6"]}
     coordConfigs:
       - {coord: y, step: -1} # Default
       - {coord: y, step: -2} # When crossing clock region

--- a/test_data/series7_bel_chains.yaml
+++ b/test_data/series7_bel_chains.yaml
@@ -1,0 +1,14 @@
+belChains:
+  - name: carryChain
+    patterns: 
+      - {source: {type: "CARRY4", port: "CO[3]"}, sink: {type: "CARRY4", port: "CI"}}
+    sites:
+      - SLICEL
+      - SLICEM
+    cells:
+      - XORCY
+      - MUXCY
+      - CARRY4
+    coordConfigs:
+      - {coord: y, step: -1} # Default
+      - {coord: y, step: -2} # When crossing clock region


### PR DESCRIPTION
This is an initial version of BELs chains support. This is related to SymbiFlow/nextpnr#262
The main target for now is to get carry chains support for xilinx architectures, but the solution should be applicable for any architecture in the end. The PR includes what type of data we should pass to nextpnr in order to get the constraining step done of the BELs chains.

Signed-off-by: Jan Kowalewski <jkowalewski@antmicro.com>