### PR TITLE
parameters: add padding when encoding integers 

### DIFF
--- a/fpga_interchange/parameter_definitions.py
+++ b/fpga_interchange/parameter_definitions.py
@@ -207,16 +207,21 @@ class ParameterDefinition():
             assert self.width is not None
             assert int_value >= 0, int_value
             assert int_value <= (2**self.width), (self.width, int_value)
-            return "{}'b{:b}".format(self.width, int_value)
+            return "{width}'b{value:0{width}b}".format(
+                width=self.width, value=int_value)
         elif self.string_format == ParameterFormat.VERILOG_HEX:
             assert self.width is not None
             assert int_value >= 0, int_value
             assert int_value <= (2**self.width), (self.width, int_value)
-            return "{}'h{:X}".format(self.width, int_value)
+            digits = (self.width + 3) // 4
+            return "{width}'h{value:0{digits}X}".format(
+                width=self.width, value=int_value, digits=digits)
         elif self.string_format == ParameterFormat.C_BINARY:
-            return '0b{:b}'.format(int_value)
+            return '0b{value:0{digits}b}'.format(value=int_value, digits=width)
         elif self.string_format == ParameterFormat.C_HEX:
-            return '0x{:X}'.format(int_value)
+            digits = (self.width + 3) // 4
+            return '0x{value:0{digits}X}'.format(
+                value=int_value, digits=digits)
 
     def decode_integer(self, str_value):
         assert self.is_integer_like()


### PR DESCRIPTION
This fix addresses a problem found when debugging the RAM test from [nextpnr](https://github.com/YosysHQ/nextpnr/tree/master/fpga_interchange/examples/tests/ram).

The problem is that the `textValues` in the netlist corresponding to the INIT parameter of the RAMB cell were not padded, e.g. as follows:

```
  - &id172
    name: ram.ram.0.0.0
    propMap:
      entries:
        - key: module_not_derived
          textValue: 00000000000000000000000000000001
        - key: src
          textValue: '/usr/local/bin/../share/yosys/xilinx/xc7_brams_map.v:296.5-320.4'
       - key: INITP_00
          textValue: "256'h4450"
        - key: INITP_01
          textValue: "256'h0"
        - key: INITP_02
          textValue: "256'h0"
        - key: INITP_03
          textValue: "256'h0"
        - key: INITP_04
          textValue: "256'h0"
        - key: INITP_05
          textValue: "256'h0"
        - key: INITP_06
          textValue: "256'h0"
        - key: INITP_07
          textValue: "256'h0"
        - key: INIT_00
          textValue: "256'h40002193366CC070F78F07FFF2A5555AA0001"
        - key: INIT_01
          textValue: "256'h0"
        - key: INIT_02
          textValue: "256'h0"
        - key: INIT_03
```

In this particular case, using the DCP generation and the following bitstream generation, yields wrong INIT values, which are actually being padded with the `25601` string to the front of each INIT property. Possibly, this is due to a wrong interpretation of the `256'h0` prefix of the textValue due to the missing characters in the string.

This PR fixes this situation by completely filling the whole textValue with zeros, in case it is necessary.