### PR TITLE
fasm: add RAMB18 features generation

### DIFF
--- a/fpga_interchange/fasm_generators/generic.py
+++ b/fpga_interchange/fasm_generators/generic.py
@@ -22,6 +22,11 @@ PhysCellInstance = namedtuple(
 )
 
 
+def invert_bitstring(string):
+    """ This function inverts all bits in a bitstring. """
+    return string.replace("1", "2").replace("0", "1").replace("2", "0")
+
+
 class LutMapper():
     def __init__(self, device_resources):
         """
@@ -345,21 +350,22 @@ class FasmGenerator():
 
         return site_thru_pips, lut_thru_pips
 
-    def get_routing_bels(self, allowed_routing_bels):
+    def get_routing_bels(self, allowed_site):
 
         routing_bels = list()
 
         for net in self.physical_netlist.nets:
             for segment in self.flattened_nets[net.name]:
                 if isinstance(segment, PhysicalSitePip):
-                    bel = segment.bel
-                    if bel not in allowed_routing_bels:
+                    site = segment.site
+                    if not site.startswith(allowed_site):
                         continue
 
-                    site = segment.site
+                    bel = segment.bel
                     pin = segment.pin
+                    is_inverting = segment.is_inverting
 
-                    routing_bels.append((site, bel, pin))
+                    routing_bels.append((site, bel, pin, is_inverting))
 
         return routing_bels
 

--- a/fpga_interchange/interchange_capnp.py
+++ b/fpga_interchange/interchange_capnp.py
@@ -760,7 +760,8 @@ def to_physical_netlist(phys_netlist_capnp):
             return PhysicalSitePip(
                 site=strs[site_pip.site],
                 bel=strs[site_pip.bel],
-                pin=strs[site_pip.pin])
+                pin=strs[site_pip.pin],
+                is_inverting=site_pip.isInverting)
 
     def convert_route_branch(route_branch_capnp):
         obj = convert_route_segment(route_branch_capnp.routeSegment)

--- a/fpga_interchange/parameter_definitions.py
+++ b/fpga_interchange/parameter_definitions.py
@@ -224,7 +224,7 @@ class ParameterDefinition():
                 value=int_value, digits=digits)
 
     def decode_integer(self, str_value):
-        assert self.is_integer_like()
+        assert self.is_integer_like(), (self.name, self.string_format)
 
         if self.string_format == ParameterFormat.BOOLEAN:
             if str_value == "FALSE":

--- a/fpga_interchange/physical_netlist.py
+++ b/fpga_interchange/physical_netlist.py
@@ -291,13 +291,15 @@ class PhysicalSitePip():
     site (str) - Site containing site pip
     bel (str) - Name of BEL that contains site pip
     pin (str) - Name of BEL pin that is the active site pip
+    is_inverting (bool) - Indicates whether the site PIP is inverted
 
     """
 
-    def __init__(self, site, bel, pin):
+    def __init__(self, site, bel, pin, is_inverting=False):
         self.site = site
         self.bel = bel
         self.pin = pin
+        self.is_inverting = is_inverting
 
         self.branches = []
 
@@ -314,6 +316,7 @@ class PhysicalSitePip():
         obj.routeSegment.sitePIP.site = string_id(self.site)
         obj.routeSegment.sitePIP.bel = string_id(self.bel)
         obj.routeSegment.sitePIP.pin = string_id(self.pin)
+        obj.routeSegment.sitePIP.isInverting = self.is_inverting
 
         descend_branch(obj, self, string_id)
 
@@ -329,13 +332,14 @@ class PhysicalSitePip():
         to generate a canonical routing tree.
 
         """
-        return ('site_pip', self.site, self.bel, self.pin)
+        return ('site_pip', self.site, self.bel, self.pin, self.is_inverting)
 
     def __str__(self):
-        return 'PhysicalSitePip({}, {}, {})'.format(
+        return 'PhysicalSitePip({}, {}, {}, {})'.format(
             repr(self.site),
             repr(self.bel),
             repr(self.pin),
+            repr(self.is_inverting),
         )
 
 


### PR DESCRIPTION
This PR adds support for writing RAMB18 features from a physical and logical netlists.

It has been tested with the ram design.

I believe there are enough handling cases at the moment to start the work towards a better generalization of the FASM feature handling, by expanding the device resources database in order to hold information on how to write FASM features for the various parameters, routing bels, pips, etc.