### PR TITLE
chip_info: Add wire types to chipdb

### DIFF
--- a/fpga_interchange/device_resources.py
+++ b/fpga_interchange/device_resources.py
@@ -82,6 +82,18 @@ Constants = namedtuple(
 )
 
 
+# Default value of a cell pin
+class WireCategory(enum.Enum):
+    General = 0
+    Special = 1
+    Global = 2
+
+
+def convert_wire_category(s):
+    """ Convert capnp enum to WireCategory. """
+    return WireCategory[first_upper(str(s))]
+
+
 class Tile(
         namedtuple(
             'Tile',


### PR DESCRIPTION
When we are happy, it'd be great to get this merged and a release cut so I can move onto globals and also rebase the other lower priority chipdb affecting PRs on top of it.