### PR TITLE
chip_info: Add more info for global placement/routing

### DIFF
--- a/fpga_interchange/populate_chip_info.py
+++ b/fpga_interchange/populate_chip_info.py
@@ -1958,7 +1958,7 @@ def populate_chip_info(device, constids, device_config):
             pin_data.max_hops = pin.get('max_hops', -1)
             pin_data.guide_placement = 1 if pin.get('guide_placement',
                                                     False) else 0
-            pin_data.force_routing = 1 if pin.get('force_routing',
+            pin_data.force_routing = 1 if pin.get('force_dedicated_routing',
                                                   False) else 0
             global_cell_data.pins.append(pin_data)
         chip_info.global_cells.append(global_cell_data)

--- a/test_data/nexus_device_config.yaml
+++ b/test_data/nexus_device_config.yaml
@@ -1,5 +1,5 @@
 # Which BEL names are global buffers for nextpnr?
-global_buffers: []
+global_buffer_bels: []
 # How should nextpnr lump BELs during analytic placement?
 buckets:
 - bucket: LUTS

--- a/test_data/series7_device_config.yaml
+++ b/test_data/series7_device_config.yaml
@@ -1,9 +1,28 @@
 # Which BEL names are global buffers for nextpnr?
-global_buffers:
+global_buffer_bels:
 - BUFG
 - BUFGCTRL
 - VCC
 - GND
+# Which cell names are global buffers, and which pins should use dedicated routing resources
+global_buffer_cells:
+  - cell: BUFG
+    pins: # list of pins that use global resources
+     - name: I # pin name
+       guide_placement: true # attempt to place so that this pin can use dedicated resources
+       max_hops: 10 # max hops of interconnect to search
+     - name: O
+       force_routing: true # the net connected to this pin _must_ use dedicated routing only
+  - cell: BUFGCTRL
+    pins:
+      - name: I0
+        guide_placement: true
+        max_hops: 10
+      - name: I1
+        guide_placement: true
+        max_hops: 10
+      - name: O
+        force_routing: true
 # How should nextpnr lump BELs during analytic placement?
 buckets:
 - bucket: FLIP_FLOPS

--- a/test_data/series7_device_config.yaml
+++ b/test_data/series7_device_config.yaml
@@ -10,9 +10,9 @@ global_buffer_cells:
     pins: # list of pins that use global resources
      - name: I # pin name
        guide_placement: true # attempt to place so that this pin can use dedicated resources
-       max_hops: 10 # max hops of interconnect to search
+       max_hops: 10 # max hops of interconnect to search (10 is for test purposes and may need to be refined)
      - name: O
-       force_routing: true # the net connected to this pin _must_ use dedicated routing only
+       force_dedicated_routing: true # the net connected to this pin _must_ use dedicated routing only
   - cell: BUFGCTRL
     pins:
       - name: I0
@@ -22,7 +22,7 @@ global_buffer_cells:
         guide_placement: true
         max_hops: 10
       - name: O
-        force_routing: true
+        force_dedicated_routing: true
 # How should nextpnr lump BELs during analytic placement?
 buckets:
 - bucket: FLIP_FLOPS


### PR DESCRIPTION
For now this info is being stored in `device_config.yaml`, when things are a bit more stable it might make sense to move it (and perhaps some of the other `device_config` stuff to the schema itself).

This'll need another release cut once merged.