### PR TITLE
device config: xc7: filter out cells2bel and routethrus

### DIFF
--- a/test_data/series7_device_config.yaml
+++ b/test_data/series7_device_config.yaml
@@ -76,9 +76,20 @@ buckets:
 # don't route through the following cells
 disabled_routethroughs:
   - BUFGCTRL
+  - BUFR
 # Do not allow cells to be placed at BELs
 disabled_cell_bel_map:
   - cell: FDRE
+    bels:
+     - TFF
+     - IFF
+     - OUTFF
+  - cell: FDCE
+    bels:
+     - TFF
+     - IFF
+     - OUTFF
+  - cell: FDPE
     bels:
      - TFF
      - IFF


### PR DESCRIPTION
BUFRs sites are allowed to be routed through for some non-clock-related signals, which might not be ideal (even though it is actually allowed).

These route-thrus can be temporarily disabled, to force the router to properly use general interconnect.

In addition, other FF cells are added to the exclusion list from the `cell <-> bel` mapping, mainly for FASM generation reasons.