### PR TITLE
Assert that (0, 0) really is empty

### DIFF
--- a/fpga_interchange/populate_chip_info.py
+++ b/fpga_interchange/populate_chip_info.py
@@ -1274,9 +1274,11 @@ class ConstantNetworkGenerator():
         tile_idx = 0
 
         # Overwrite tile at 0,0 assuming that it is a NULL tile.
-        tile_type_name = self.chip_info.tile_types[self.chip_info.
-                                                   tiles[tile_idx].type].name
-        assert tile_type_name == 'NULL', tile_type_name
+        null_tile_type = self.chip_info.tile_types[self.chip_info.
+                                                   tiles[tile_idx].type]
+        assert null_tile_type.name == 'NULL', null_tile_type.name
+        assert len(null_tile_type.wire_data) == 0, len(
+            null_tile_type.wire_data)
 
         self.constants.gnd_bel_tile = tile_idx
         self.constants.vcc_bel_tile = tile_idx


### PR DESCRIPTION
This improves the contract checking for #34, which does need to be fixed properly at some point, but at least makes a breach of this contract result in a Python assertion failure rather than a nextpnr segfault (leading to the fun debugging https://github.com/gatecat/prjoxide/commit/e62452795d6ec8a4d0207df88b8d49d0bed0207e)