### PR TITLE
populate chip info: fix assertion

### DIFF
--- a/fpga_interchange/populate_chip_info.py
+++ b/fpga_interchange/populate_chip_info.py
@@ -1276,8 +1276,12 @@ class ConstantNetworkGenerator():
         # Overwrite tile at 0,0 assuming that it is a NULL tile.
         null_tile_type = self.chip_info.tile_types[self.chip_info.
                                                    tiles[tile_idx].type]
+        # FIXME: Make these checks more robust and not dependant on
+        #        non-well-defined naming conventions.
         assert null_tile_type.name == 'NULL', null_tile_type.name
-        assert len(null_tile_type.wire_data) == 0, len(
+        contains_dummy_wires = all(
+            'DUMMY' in wire.name for wire in null_tile_type.wire_data)
+        assert len(null_tile_type.wire_data) == 0 or contains_dummy_wires, len(
             null_tile_type.wire_data)
 
         self.constants.gnd_bel_tile = tile_idx

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="python-fpga-interchange",
-    version="0.0.9",
+    version="0.0.13",
     author="SymbiFlow Authors",
     author_email="symbiflow@lists.librecores.org",
     description="Python library for reading and writing FPGA interchange files",


### PR DESCRIPTION
It appears that, for xilinx devices, the `(0, 0)` tile contains one wire named `DUMMYFOO`. This PR fixes the assertion to not fail if all wires in the `null_tile_type` are dummy in reality.

This PR also syncs the setup version with the current tag.