### PR TITLE
Nexus FASM generation

### DIFF
--- a/fpga_interchange/fasm_generator.py
+++ b/fpga_interchange/fasm_generator.py
@@ -12,6 +12,7 @@ import argparse
 
 from fpga_interchange.interchange_capnp import Interchange
 from fpga_interchange.fasm_generators.xc7 import XC7FasmGenerator
+from fpga_interchange.fasm_generators.nexus import NexusFasmGenerator
 
 
 def main():
@@ -34,6 +35,7 @@ def main():
 
     family_map = {
         "xc7": XC7FasmGenerator,
+        "nexus": NexusFasmGenerator,
     }
 
     device_resources = args.device_resources

--- a/fpga_interchange/fasm_generators/generic.py
+++ b/fpga_interchange/fasm_generators/generic.py
@@ -298,8 +298,11 @@ class FasmGenerator():
                 bel_pins=bel_pins,
                 attributes=cell_attr)
 
-    def fill_pip_features(self, pip_feature_format, extra_pip_features,
-                          avail_lut_thrus):
+    def fill_pip_features(self,
+                          pip_feature_format,
+                          extra_pip_features,
+                          avail_lut_thrus,
+                          wire_rename=lambda x: x):
         """
         This function generates all features corresponding to the physical routing
         PIPs present in the physical netlist.
@@ -346,8 +349,9 @@ class FasmGenerator():
                             extra_pip_features[tile_type_name].add((tile,
                                                                     wire1))
 
-                        self.add_pip_feature((tile, wire0, wire1),
-                                             pip_feature_format)
+                        self.add_pip_feature(
+                            (tile, wire_rename(wire0), wire_rename(wire1)),
+                            pip_feature_format)
 
                         continue
 

--- a/fpga_interchange/fasm_generators/generic.py
+++ b/fpga_interchange/fasm_generators/generic.py
@@ -334,6 +334,7 @@ class FasmGenerator():
                     wire1_id = self.device_resources.string_index[wire1]
 
                     pip = tile_type.pip(wire0_id, wire1_id)
+                    tile = tile_info.sub_tile_prefices[pip.subTile]
                     if pip.which() != "pseudoCells":
                         if tile_type_name in extra_pip_features:
                             extra_pip_features[tile_type_name].add((tile,
@@ -367,6 +368,10 @@ class FasmGenerator():
                             if any(self.device_resources.strs[p] == bel_pin.
                                    name for p in pcell.pins):
                                 pin = bel_pin.name
+
+                        if pin == None:
+                            # TODO: GND driver has no input pin
+                            continue
 
                         assert pin
 

--- a/fpga_interchange/fasm_generators/generic.py
+++ b/fpga_interchange/fasm_generators/generic.py
@@ -203,6 +203,7 @@ class FasmGenerator():
 
         self.routing_bels = dict()
 
+        self.annotations = dict()
         self.pips_features = set()
         self.cells_features = set()
 
@@ -213,6 +214,9 @@ class FasmGenerator():
 
         return "# Created by the FPGA Interchange FASM Generator (v{})".format(
             version)
+
+    def add_annotation(self, key, value):
+        self.annotations[key] = value
 
     def add_cell_feature(self, feature_parts):
         feature_str = ".".join(feature_parts)
@@ -457,6 +461,10 @@ class FasmGenerator():
 
         with open(fasm_file, "w") as f:
             print(self.get_origin_line(), file=f)
+            for key, value in sorted(
+                    self.annotations.items(), key=lambda x: x[0]):
+                print('{{ {}="{}" }}'.format(key, value), file=f)
+
             for cell_feature in sorted(list(self.cells_features)):
                 print(cell_feature, file=f)
 

--- a/fpga_interchange/fasm_generators/generic.py
+++ b/fpga_interchange/fasm_generators/generic.py
@@ -153,8 +153,13 @@ class LutMapper():
         return self.get_phys_lut_init(logical_init_value, lut_element, lut_bel,
                                       lut_cell, phys_to_log)
 
-    def get_phys_wire_lut_init(self, logical_init_value, site_type, cell_type,
-                               bel, bel_pin):
+    def get_phys_wire_lut_init(self,
+                               logical_init_value,
+                               site_type,
+                               cell_type,
+                               bel,
+                               bel_pin,
+                               lut_pin=None):
         """
         Returns the LUTs physical INIT parameter mapping of a LUT-thru wire
 
@@ -163,9 +168,13 @@ class LutMapper():
 
         lut_element, lut_bel = self.find_lut_bel(site_type, bel)
         lut_cell = self.lut_cells[cell_type]
-        assert len(lut_cell.pins) == 1, (lut_cell.name, lut_cell.pins)
         phys_to_log = dict((pin, None) for pin in lut_bel.pins)
-        phys_to_log[bel_pin] = lut_cell.pins[0]
+
+        if lut_pin == None:
+            assert len(lut_cell.pins) == 1, (lut_cell.name, lut_cell.pins)
+            phys_to_log[bel_pin] = lut_cell.pins[0]
+        else:
+            phys_to_log[bel_pin] = lut_pin
 
         return self.get_phys_lut_init(logical_init_value, lut_element, lut_bel,
                                       lut_cell, phys_to_log)

--- a/fpga_interchange/fasm_generators/generic.py
+++ b/fpga_interchange/fasm_generators/generic.py
@@ -380,6 +380,13 @@ class FasmGenerator():
                         if pin == None:
                             # GND/VCC driver LUT has no input pin
                             assert bel_name in avail_lut_thrus, bel_name
+                            key = (net.name, site, bel_name)
+                            assert key not in lut_thru_pips
+
+                            lut_thru_pips[key] = {
+                                "pin_name": None,
+                                "is_valid": True
+                            }
                             continue
 
                         assert pin

--- a/fpga_interchange/fasm_generators/generic.py
+++ b/fpga_interchange/fasm_generators/generic.py
@@ -378,7 +378,8 @@ class FasmGenerator():
                                 pin = bel_pin.name
 
                         if pin == None:
-                            # TODO: GND driver has no input pin
+                            # GND/VCC driver LUT has no input pin
+                            assert bel_name in avail_lut_thrus, bel_name
                             continue
 
                         assert pin

--- a/fpga_interchange/fasm_generators/nexus.py
+++ b/fpga_interchange/fasm_generators/nexus.py
@@ -18,19 +18,67 @@ from itertools import product
 
 from fpga_interchange.fasm_generators.generic import FasmGenerator
 
+VCC_NET = "GLOBAL_LOGIC1"
+GND_NET = "GLOBAL_LOGIC0"
+
 
 class NexusFasmGenerator(FasmGenerator):
     def handle_pips(self):
         pip_feature_format = "{tile}.PIP.{wire1}.{wire0}"
         avail_lut_thrus = list()
         for _, _, _, _, bel, bel_type in self.device_resources.yield_bels():
-            if bel_type == "LUT4":
+            if bel_type == "OXIDE_COMB":
                 avail_lut_thrus.append(bel)
 
         site_thru_pips, lut_thru_pips = self.fill_pip_features(
             pip_feature_format, {},
             avail_lut_thrus,
             wire_rename=lambda x: x.replace(":", "__"))
+        self.handle_lut_thru(lut_thru_pips)
+
+    def write_lut(self, tile, bel, init):
+        bel_tile = "{}__PLC".format(tile)
+        bel_prefix = bel.replace("_LUT", ".K")
+        self.add_cell_feature((bel_tile, bel_prefix,
+                               "INIT[15:0] = 16'b{}".format(init)))
+
+    def handle_lut_thru(self, lut_thru_pips):
+        for (net_name, site, bel), pin in lut_thru_pips.items():
+            pin_name = pin["pin_name"]
+            is_valid = pin["is_valid"]
+            if not is_valid:
+                continue
+            tile_name, _ = self.get_tile_info_at_site(site)
+            site_type = list(
+                self.device_resources.site_name_to_site[site].keys())[0]
+
+            if net_name == VCC_NET:
+                lut_init = self.lut_mapper.get_const_lut_init(
+                    1, site_type, bel)
+            elif net_name == GND_NET:
+                lut_init = self.lut_mapper.get_const_lut_init(
+                    0, site_type, bel)
+            else:
+                lut_init = self.lut_mapper.get_phys_wire_lut_init(
+                    2, site_type, "LUT1", bel, pin_name)
+            self.write_lut(tile_name, bel, lut_init)
+
+    def handle_luts(self):
+        """
+        This function handles LUTs FASM features generation
+        """
+        for cell_instance, cell_data in self.physical_cells_instances.items():
+            if cell_data.cell_type != "LUT4":
+                continue
+
+            init_param = self.device_resources.get_parameter_definition(
+                cell_data.cell_type, "INIT")
+            init_value = init_param.decode_integer(
+                cell_data.attributes["INIT"])
+
+            phys_lut_init = self.lut_mapper.get_phys_cell_lut_init(
+                init_value, cell_data)
+            self.write_lut(cell_data.tile_name, cell_data.bel, phys_lut_init)
 
     def handle_io(self):
         allowed_io_types = {
@@ -53,6 +101,7 @@ class NexusFasmGenerator(FasmGenerator):
         dev_name = self.device_resources.device_resource_capnp.name
         self.add_annotation("oxide.device", dev_name)
         self.add_annotation("oxide.device_variant", "ES")
+        self.handle_luts()
         self.handle_io()
         # Handling PIPs and Route-throughs
         self.handle_pips()

--- a/fpga_interchange/fasm_generators/nexus.py
+++ b/fpga_interchange/fasm_generators/nexus.py
@@ -21,13 +21,32 @@ from fpga_interchange.fasm_generators.generic import FasmGenerator
 
 class NexusFasmGenerator(FasmGenerator):
     def handle_pips(self):
-        pip_feature_format = "PIP.{tile}.{wire1}.{wire0}"
+        pip_feature_format = "{tile}.PIP.{wire1}.{wire0}"
         site_thru_pips, lut_thru_pips = self.fill_pip_features(
-            pip_feature_format, {}, {})
+            pip_feature_format, {}, {},
+            wire_rename=lambda x: x.replace(":", "__"))
+
+    def handle_io(self):
+        allowed_io_types = {
+            "OB": [
+                "BASE_TYPE.OUTPUT_LVCMOS33",
+                "TMUX.INV",
+            ],
+            "IB": [
+                "BASE_TYPE.INPUT_LVCMOS33",
+            ]
+        }
+        for cell_instance, cell_data in self.physical_cells_instances.items():
+            if cell_data.cell_type not in allowed_io_types:
+                continue
+            for feature in allowed_io_types[cell_data.cell_type]:
+                self.add_cell_feature((cell_data.site_name, cell_data.bel,
+                                       feature))
 
     def fill_features(self):
         dev_name = self.device_resources.device_resource_capnp.name
         self.add_annotation("oxide.device", dev_name)
         self.add_annotation("oxide.device_variant", "ES")
+        self.handle_io()
         # Handling PIPs and Route-throughs
         self.handle_pips()

--- a/fpga_interchange/fasm_generators/nexus.py
+++ b/fpga_interchange/fasm_generators/nexus.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+"""
+This file defines the Nexus devices FASM generator class.
+"""
+import re
+from collections import namedtuple
+from enum import Enum
+from itertools import product
+
+from fpga_interchange.fasm_generators.generic import FasmGenerator
+
+
+class NexusFasmGenerator(FasmGenerator):
+    def handle_pips(self):
+        pip_feature_format = "PIP.{tile}.{wire1}.{wire0}"
+        site_thru_pips, lut_thru_pips = self.fill_pip_features(
+            pip_feature_format, {}, {})
+
+    def fill_features(self):
+        # Handling PIPs and Route-throughs
+        self.handle_pips()

--- a/fpga_interchange/fasm_generators/nexus.py
+++ b/fpga_interchange/fasm_generators/nexus.py
@@ -84,6 +84,32 @@ class NexusFasmGenerator(FasmGenerator):
             feature = "{}.{}".format(dst_wire, pin)
             self.add_cell_feature((tile, "PIP", feature))
 
+    def handle_slice_ff(self):
+        for cell_instance, cell_data in self.physical_cells_instances.items():
+            if not cell_data.cell_type.startswith("FD1P3"):
+                continue
+            bel_tile = "{}__PLC".format(cell_data.tile_name)
+            bel_prefix = cell_data.bel.replace("_FF", ".REG")
+
+            self.add_cell_feature((bel_tile, bel_prefix, "USED.YES"))
+            regset = "SET" if cell_data.cell_type in ("FD1P3BX",
+                                                      "FD1P3JX") else "RESET"
+            self.add_cell_feature((bel_tile, bel_prefix,
+                                   "USED.{}".format(regset)))
+            self.add_cell_feature((bel_tile, bel_prefix, "LSRMODE.LSR"))
+            self.add_cell_feature((bel_tile, bel_prefix,
+                                   "SEL.DF"))  # TODO: LUT->FF path
+
+            slice_prefix = cell_data.bel.split("_")[0]
+            srmode = "ASYNC" if cell_data.cell_type in (
+                "FD1P3BX", "FD1P3DX") else "LSR_OVER_CE"
+            self.add_cell_feature((bel_tile, slice_prefix,
+                                   "SRMODE.{}".format(srmode)))
+            # TODO: control set inversion/constants
+            self.add_cell_feature((bel_tile, slice_prefix, "CLKMUX.CLK"))
+            self.add_cell_feature((bel_tile, slice_prefix, "LSRMUX.LSR"))
+            self.add_cell_feature((bel_tile, slice_prefix, "CEMUX.CE"))
+
     def handle_luts(self):
         """
         This function handles LUTs FASM features generation
@@ -126,4 +152,5 @@ class NexusFasmGenerator(FasmGenerator):
         self.handle_io()
         # Handling PIPs and Route-throughs
         self.handle_pips()
+        self.handle_slice_ff()
         self.handle_slice_routing_bels()

--- a/fpga_interchange/fasm_generators/nexus.py
+++ b/fpga_interchange/fasm_generators/nexus.py
@@ -60,7 +60,7 @@ class NexusFasmGenerator(FasmGenerator):
                     0, site_type, bel)
             else:
                 lut_init = self.lut_mapper.get_phys_wire_lut_init(
-                    2, site_type, "LUT1", bel, pin_name)
+                    2, site_type, "LUT4", bel, pin_name, "A")
             self.write_lut(tile_name, bel, lut_init)
 
     def handle_luts(self):

--- a/fpga_interchange/fasm_generators/nexus.py
+++ b/fpga_interchange/fasm_generators/nexus.py
@@ -26,5 +26,8 @@ class NexusFasmGenerator(FasmGenerator):
             pip_feature_format, {}, {})
 
     def fill_features(self):
+        dev_name = self.device_resources.device_resource_capnp.name
+        self.add_annotation("oxide.device", dev_name)
+        self.add_annotation("oxide.device_variant", "ES")
         # Handling PIPs and Route-throughs
         self.handle_pips()

--- a/fpga_interchange/fasm_generators/nexus.py
+++ b/fpga_interchange/fasm_generators/nexus.py
@@ -22,8 +22,14 @@ from fpga_interchange.fasm_generators.generic import FasmGenerator
 class NexusFasmGenerator(FasmGenerator):
     def handle_pips(self):
         pip_feature_format = "{tile}.PIP.{wire1}.{wire0}"
+        avail_lut_thrus = list()
+        for _, _, _, _, bel, bel_type in self.device_resources.yield_bels():
+            if bel_type == "LUT4":
+                avail_lut_thrus.append(bel)
+
         site_thru_pips, lut_thru_pips = self.fill_pip_features(
-            pip_feature_format, {}, {},
+            pip_feature_format, {},
+            avail_lut_thrus,
             wire_rename=lambda x: x.replace(":", "__"))
 
     def handle_io(self):


### PR DESCRIPTION
Currently, this is very minimal FASM generation for the Nexus (routing and IO), enough to build a wire between a button and an LED.

Remaining issues for a blinky:
 - [x] LUTs, LUT-route-throughs and constant-0 LUT handling
 - [x] flipflops
 - [x] The 'DED' special IO that happens to be used for LED0
 - [ ] possibly CIBMUX handling: https://github.com/YosysHQ/nextpnr/blob/24ae205f20f0e1a0326e48002ab14d5bacfca1ef/nexus/fasm.cc#L272-L287
 - [ ] internal oscillator, iirc the 12MHz clock that's supposed to come from the FTDI on the EVN board is dodgy in practice
