### PR TITLE
Add interchange clustering definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ env
 *.swp
 *.swo
 *.yaml
+!test_data/*

--- a/fpga_interchange/chip_info.py
+++ b/fpga_interchange/chip_info.py
@@ -1135,8 +1135,8 @@ class ChipInfo():
         self.name = ''
         self.generator = ''
 
-        # Note: Increment by 1 this whenever schema changes.
-        self.version = 10
+        # Note: Increment by 1 this whenever schema or the nextpnr chip database structure changes.
+        self.version = 11
         self.width = 0
         self.height = 0
 

--- a/fpga_interchange/nextpnr.py
+++ b/fpga_interchange/nextpnr.py
@@ -81,5 +81,7 @@ class BbaWriter():
 
     def check_labels(self):
         refs_and_labels = self.refs & self.labels
-        assert len(refs_and_labels) == len(self.refs)
-        assert len(refs_and_labels) == len(self.labels)
+        assert len(refs_and_labels) == len(self.refs), "{} vs. {}".format(
+            len(refs_and_labels), len(self.refs))
+        assert len(refs_and_labels) == len(self.labels), "{} vs. {}".format(
+            len(refs_and_labels), len(self.labels))

--- a/test_data/series7_device_config.yaml
+++ b/test_data/series7_device_config.yaml
@@ -94,3 +94,61 @@ disabled_cell_bel_map:
      - TFF
      - IFF
      - OUTFF
+disabled_site_pips:
+  - bels:
+     - A6LUT
+     - B6LUT
+     - C6LUT
+     - D6LUT
+    ipin: A6
+    opin: O6
+clusters:
+- name: CARRY_CHAIN
+  chainable_ports:
+    - cell_source: CO[3]
+      cell_sink: CI
+      bel_source: CO3
+      bel_sink: CIN
+      avg_x_offset: 0
+      avg_y_offset: -1
+  root_cell_types:
+    - CARRY4
+  cluster_cells:
+    - cells:
+        - LUT1
+        - LUT2
+        - LUT3
+        - LUT4
+        - LUT5
+        - LUT6
+      ports:
+        - S[3]
+        - S[2]
+        - S[1]
+        - S[0]
+    - cells:
+        - FDRE
+        - FDSE
+        - FDCE
+        - FDPE
+      ports:
+        - O[3]
+        - O[2]
+        - O[1]
+        - O[0]
+- name: LUT_FF
+  root_cell_types:
+    - FDRE
+    - FDSE
+    - FDCE
+    - FDPE
+  cluster_cells:
+    - cells:
+        - LUT1
+        - LUT2
+        - LUT3
+        - LUT4
+        - LUT5
+        - LUT6
+      ports:
+        - D


### PR DESCRIPTION
This PR is based on https://github.com/SymbiFlow/python-fpga-interchange/pull/70 and aims at redefining the BEL chaining to make it more flexible and allow also the definition of clusters to guide nextpnr placement.

It mainly detaches from using the schema, and directly adds information to the nextpnr chipdb.

It still is marked as WIP as it needs more iterations to get to a stable and reviewable state.