### PR TITLE
nexus: Basic FASM generator support for BRAM

### DIFF
--- a/fpga_interchange/fasm_generators/nexus.py
+++ b/fpga_interchange/fasm_generators/nexus.py
@@ -95,7 +95,7 @@ class NexusFasmGenerator(FasmGenerator):
             regset = "SET" if cell_data.cell_type in ("FD1P3BX",
                                                       "FD1P3JX") else "RESET"
             self.add_cell_feature((bel_tile, bel_prefix,
-                                   "USED.{}".format(regset)))
+                                   "REGSET.{}".format(regset)))
             self.add_cell_feature((bel_tile, bel_prefix, "LSRMODE.LSR"))
             self.add_cell_feature((bel_tile, bel_prefix,
                                    "SEL.DF"))  # TODO: LUT->FF path

--- a/test_data/nexus_device_config.yaml
+++ b/test_data/nexus_device_config.yaml
@@ -1,5 +1,19 @@
 # Which BEL names are global buffers for nextpnr?
-global_buffer_bels: []
+global_buffer_bels:
+- DCC
+# Which cell names are global buffers, and which pins should use dedicated routing resources
+global_buffer_cells:
+  - cell: DCC
+    pins: # list of pins that use global resources
+     - name: CLKI # pin name
+       guide_placement: true # attempt to place so that this pin can use dedicated resources
+       max_hops: 10 # max hops of interconnect to search (10 is for test purposes and may need to be refined)
+     - name: CLKO
+       force_dedicated_routing: true # the net connected to this pin _must_ use dedicated routing only
+  - cell: OSC_CORE
+    pins: # list of pins that use global resources
+     - name: HFCLKOUT
+       force_dedicated_routing: true # the net connected to this pin _must_ use dedicated routing only
 # How should nextpnr lump BELs during analytic placement?
 buckets:
 - bucket: LUTS
@@ -15,3 +29,9 @@ buckets:
   cells:
    - IB
    - OB
+- bucket: BRAMs
+  cells:
+   - DP16K_MODE
+   - PDP16K_MODE
+   - PDPSC16K_MODE
+


### PR DESCRIPTION
Please note that this currently sits on top of #92 and #96.

With latest prjoxide master and YosysHQ/nextpnr#728, it is possible to build and run a simple BRAM test on hardware (LIFCL-40-EVN) successfully.