### PR TITLE
chip_info: Don't require 0,0 tile type to be exactly NULL

### DIFF
--- a/fpga_interchange/populate_chip_info.py
+++ b/fpga_interchange/populate_chip_info.py
@@ -1296,7 +1296,6 @@ class ConstantNetworkGenerator():
                                                    tiles[tile_idx].type]
         # FIXME: Make these checks more robust and not dependant on
         #        non-well-defined naming conventions.
-        assert null_tile_type.name == 'NULL', null_tile_type.name
         contains_dummy_wires = all(
             'DUMMY' in wire.name for wire in null_tile_type.wire_data)
         assert len(null_tile_type.wire_data) == 0 or contains_dummy_wires, len(


### PR DESCRIPTION
The check that there are no wires in this tile (other than dummy wires) is more relevant in any case, so there's no need any more to so strict about the name of the tile type.

This is needed for UltraScale+ support, where the 0,0 tile is `HPIO_TERM_L_DA6_TERM_T_FT` but still empty. 

