### PR TITLE
cluster: add field to allow clusters in different sites

### DIFF
--- a/fpga_interchange/chip_info.py
+++ b/fpga_interchange/chip_info.py
@@ -686,7 +686,8 @@ class Cluster():
     fields = ['chainable_ports', 'cluster_cell_ports']
     field_types = ['ChainablePortPOD', 'ClusterCellPortPOD']
 
-    def __init__(self, name, chainable_ports, root_cell_types, cluster_cells):
+    def __init__(self, name, chainable_ports, root_cell_types, cluster_cells,
+                 out_of_site_clusters):
         # Chain name
         self.name = name
 
@@ -706,6 +707,8 @@ class Cluster():
         for cell in cluster_cells:
             for cell, port in product(cell["cells"], cell["ports"]):
                 self.cluster_cell_ports.append(ClusterCellPort(cell, port))
+
+        self.out_of_site_clusters = out_of_site_clusters
 
     def field_label(self, label_prefix, field):
         prefix = '{}.{}.{}'.format(label_prefix, self.name, field)
@@ -738,6 +741,8 @@ class Cluster():
         for field in self.fields:
             bba.ref(self.field_label(label_prefix, field))
             bba.u32(len(getattr(self, field)))
+
+        bba.u32(1 if self.out_of_site_clusters else 0)
 
 
 class PackagePin():

--- a/fpga_interchange/chip_info.py
+++ b/fpga_interchange/chip_info.py
@@ -1141,7 +1141,7 @@ class ChipInfo():
         self.generator = ''
 
         # Note: Increment by 1 this whenever schema or the nextpnr chip database structure changes.
-        self.version = 11
+        self.version = 12
         self.width = 0
         self.height = 0
 

--- a/fpga_interchange/populate_chip_info.py
+++ b/fpga_interchange/populate_chip_info.py
@@ -1858,7 +1858,8 @@ def populate_chip_info(device, constids, device_config):
         cluster_name = cluster["name"]
         cluster_obj = Cluster(cluster_name, cluster.get("chainable_ports", []),
                               cluster["root_cell_types"],
-                              cluster.get("cluster_cells", []))
+                              cluster.get("cluster_cells", []),
+                              cluster.get("out_of_site_clusters", False))
 
         chip_info.clusters.append(cluster_obj)
 

--- a/test_data/series7_device_config.yaml
+++ b/test_data/series7_device_config.yaml
@@ -94,6 +94,11 @@ disabled_cell_bel_map:
      - TFF
      - IFF
      - OUTFF
+  - cell: FDSE
+    bels:
+     - TFF
+     - IFF
+     - OUTFF
 disabled_site_pips:
   - bels:
      - A6LUT
@@ -152,3 +157,12 @@ clusters:
         - LUT6
       ports:
         - D
+- name: IDELAY_ISERDES
+  root_cell_types:
+    - IDELAYE2
+  out_of_site_clusters: true
+  cluster_cells:
+    - cells:
+        - ISERDESE2
+      ports:
+        - DATAOUT


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR adds an additional information to the clusters to allow out of site expansions when looking for a valid BEL.