### PR TITLE
fasm: xc7: add handling of IOBs and complete carry features

### DIFF
--- a/fpga_interchange/device_resources.py
+++ b/fpga_interchange/device_resources.py
@@ -969,6 +969,21 @@ class DeviceResources():
         return to_logical_netlist(self.device_resource_capnp.primLibs,
                                   self.strs)
 
+    def get_macro_instances(self):
+        prims = self.get_primitive_library()
+
+        if 'macros' not in prims.libraries:
+            return
+
+        macro_lib = prims.libraries['macros']
+        for cell_name, cell in sorted(
+                macro_lib.cells.items(), key=lambda x: x[0]):
+            macro_name = cell_name
+
+            for inst_name, inst in sorted(
+                    cell.cell_instances.items(), key=lambda x: x[0]):
+                yield (macro_name, inst_name, inst.cell_name)
+
     def get_constants(self):
         constants = self.device_resource_capnp.constants
 

--- a/fpga_interchange/fasm_generators/generic.py
+++ b/fpga_interchange/fasm_generators/generic.py
@@ -141,7 +141,23 @@ class FasmGenerator():
 
             bel = placement.bel
             bel_pins = placement.pins
+
             cell_attr = self.logical_cells_instances.get(cell_name, None)
+
+            if cell_attr is None:
+                # If no attrs were found, this cell may be part of a macro
+                # expansion. Check if this may be the case
+                for _, _, macro_cell_name in self.device_resources.get_macro_instances(
+                ):
+                    if cell_type != macro_cell_name:
+                        continue
+
+                    orig_cell_name = cell_name.split("/")[0]
+                    cell_attr = self.logical_cells_instances.get(
+                        orig_cell_name, None)
+
+                    assert cell_attr, cell_name
+                    break
 
             self.physical_cells_instances[cell_name] = PhysCellInstance(
                 cell_type=cell_type,

--- a/fpga_interchange/fasm_generators/xc7_iobs.py
+++ b/fpga_interchange/fasm_generators/xc7_iobs.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+"""
+This file contains all the currently supported IOSTANDARD, slewand DRIVE combinations that
+translate into specific features.
+
+This is a temporary solution before adding all the information necessary to generate a
+correct FASM out of a physical netlist directly without using additional data files.
+"""
+
+iob_settings = {
+    "LVCMOS12_LVCMOS15_LVCMOS18.IN": {
+        "iostandards": {
+            'LVCMOS12': [],
+            'LVCMOS15': [],
+            'LVCMOS18': []
+        },
+        "slews": [],
+    },
+    "LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVDS_25_LVTTL_SSTL135_SSTL15_TMDS_33.IN_ONLY":
+    {
+        "iostandards": {
+            'LVCMOS12': [],
+            'LVCMOS15': [],
+            'LVCMOS18': [],
+            'LVCMOS25': [],
+            'LVCMOS33': [],
+            'LVTTL': [],
+            'SSTL135': [],
+            'SSTL15': [],
+            'DIFF_SSTL135': [],
+            'DIFF_SSTL15': []
+        },
+        "slews": [],
+    },
+    "LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL.SLEW.FAST": {
+        "iostandards": {
+            'LVCMOS12': [],
+            'LVCMOS15': [],
+            'LVCMOS18': [],
+            'LVCMOS25': [],
+            'LVCMOS33': [],
+            'LVTTL': []
+        },
+        "slews": ['FAST'],
+    },
+    "LVCMOS12_LVCMOS15_LVCMOS18_SSTL135_SSTL15.STEPDOWN": {
+        "iostandards": {
+            'LVCMOS12': [],
+            'LVCMOS15': [],
+            'LVCMOS18': [],
+            'SSTL135': [],
+            'SSTL15': [],
+            'DIFF_SSTL135': [],
+            'DIFF_SSTL15': []
+        },
+        "slews": [],
+    },
+    "LVCMOS25_LVCMOS33_LVTTL.IN": {
+        "iostandards": {
+            'LVCMOS25': [],
+            'LVCMOS33': [],
+            'LVTTL': []
+        },
+        "slews": [],
+    },
+    "SSTL135_SSTL15.IN": {
+        "iostandards": {
+            'SSTL135': [],
+            'SSTL15': []
+        },
+        "slews": [],
+    },
+    "LVCMOS12.DRIVE.I12": {
+        "iostandards": {
+            'LVCMOS12': [12]
+        },
+        "slews": [],
+    },
+    "LVCMOS12.DRIVE.I4": {
+        "iostandards": {
+            'LVCMOS12': [4]
+        },
+        "slews": [],
+    },
+    "LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL_SSTL135_SSTL15.SLEW.SLOW":
+    {
+        "iostandards": {
+            'LVCMOS12': [],
+            'LVCMOS15': [],
+            'LVCMOS18': [],
+            'LVCMOS25': [],
+            'LVCMOS33': [],
+            'LVTTL': [],
+            'SSTL135': [],
+            'SSTL15': [],
+            'DIFF_SSTL135': [],
+            'DIFF_SSTL15': []
+        },
+        "slews": ['SLOW'],
+    },
+    "LVCMOS12_LVCMOS25.DRIVE.I8": {
+        "iostandards": {
+            'LVCMOS12': [8],
+            'LVCMOS25': [8]
+        },
+        "slews": [],
+    },
+    "LVCMOS15.DRIVE.I12": {
+        "iostandards": {
+            'LVCMOS15': [12]
+        },
+        "slews": [],
+    },
+    "LVCMOS15.DRIVE.I8": {
+        "iostandards": {
+            'LVCMOS15': [8]
+        },
+        "slews": [],
+    },
+    "LVCMOS15_LVCMOS18_LVCMOS25.DRIVE.I4": {
+        "iostandards": {
+            'LVCMOS15': [4],
+            'LVCMOS18': [4],
+            'LVCMOS25': [4]
+        },
+        "slews": [],
+    },
+    "LVCMOS15_SSTL15.DRIVE.I16_I_FIXED": {
+        "iostandards": {
+            'LVCMOS15': [16],
+            'SSTL15': [],
+            'DIFF_SSTL15': []
+        },
+        "slews": [],
+    },
+    "LVCMOS18.DRIVE.I12_I8": {
+        "iostandards": {
+            'LVCMOS18': [8, 12]
+        },
+        "slews": [],
+    },
+    "LVCMOS18.DRIVE.I16": {
+        "iostandards": {
+            'LVCMOS18': [16]
+        },
+        "slews": [],
+    },
+    "LVCMOS18.DRIVE.I24": {
+        "iostandards": {
+            'LVCMOS18': [24]
+        },
+        "slews": [],
+    },
+    "LVCMOS25.DRIVE.I12": {
+        "iostandards": {
+            'LVCMOS25': [12]
+        },
+        "slews": [],
+    },
+    "LVCMOS25.DRIVE.I16": {
+        "iostandards": {
+            'LVCMOS25': [16]
+        },
+        "slews": [],
+    },
+    "LVCMOS33.DRIVE.I16": {
+        "iostandards": {
+            'LVCMOS33': [16]
+        },
+        "slews": [],
+    },
+    "LVCMOS33_LVTTL.DRIVE.I12_I16": {
+        "iostandards": {
+            'LVCMOS33': [12],
+            'LVTTL': [16]
+        },
+        "slews": [],
+    },
+    "LVCMOS33_LVTTL.DRIVE.I12_I8": {
+        "iostandards": {
+            'LVCMOS33': [8],
+            'LVTTL': [8, 12]
+        },
+        "slews": [],
+    },
+    "LVCMOS33_LVTTL.DRIVE.I4": {
+        "iostandards": {
+            'LVCMOS33': [4],
+            'LVTTL': [4]
+        },
+        "slews": [],
+    },
+    "LVTTL.DRIVE.I24": {
+        "iostandards": {
+            'LVTTL': [24]
+        },
+        "slews": [],
+    },
+    "SSTL135.DRIVE.I_FIXED": {
+        "iostandards": {
+            'SSTL135': [],
+            'DIFF_SSTL135': []
+        },
+        "slews": [],
+    },
+    "SSTL135_SSTL15.SLEW.FAST": {
+        "iostandards": {
+            'SSTL135': [],
+            'SSTL15': [],
+            'DIFF_SSTL135': [],
+            'DIFF_SSTL15': []
+        },
+        "slews": ['FAST'],
+    },
+    "LVDS_25_SSTL135_SSTL15.IN_DIFF": {
+        "iostandards": {
+            'DIFF_SSTL135': [],
+            'DIFF_SSTL15': []
+        },
+        "slews": [],
+    },
+}


### PR DESCRIPTION
Adds support for:

- all supported IOSTANDARDS, DRIVE and SLEW combinations present in prjxray-db
- missing CARRY features