### PR TITLE
Fix fasm CLBLM and SING tiles

### DIFF
--- a/fpga_interchange/fasm_generators/xc7.py
+++ b/fpga_interchange/fasm_generators/xc7.py
@@ -178,7 +178,6 @@ class XC7FasmGenerator(FasmGenerator):
                     else:
                         fasm_features.append("{}_{}".format(attr, init_value))
 
-
             for fasm_feature in fasm_features:
                 self.add_cell_feature((tile_name, bram_prefix, fasm_feature))
 
@@ -456,25 +455,25 @@ class XC7FasmGenerator(FasmGenerator):
         ]
         excluded_bels += ["CLKINV"]
 
-        carry_cy        = ["{}CY0".format(bel) for bel in ["A", "B", "C", "D"]]
-        slicem_srl_mux  = {
+        carry_cy = ["{}CY0".format(bel) for bel in ["A", "B", "C", "D"]]
+        slicem_srl_mux = {
             "CDI1MUX": {
-                "LUT"   : "CLUT",
-                "DI"    : "DI_DMC31",
-                "DMC31" : "DI_DMC31",
-                "CI"    : "CI"
+                "LUT": "CLUT",
+                "DI": "DI_DMC31",
+                "DMC31": "DI_DMC31",
+                "CI": "CI"
             },
             "BDI1MUX": {
-                "LUT"   : "BLUT",
-                "DI"    : "DI_CMC31",
-                "CMC31" : "DI_CMC31",
-                "BI"    : "BI"
+                "LUT": "BLUT",
+                "DI": "DI_CMC31",
+                "CMC31": "DI_CMC31",
+                "BI": "BI"
             },
             "ADI1MUX": {
-                "LUT"   : "ALUT",
-                "BDI1"  : "BDI1_BMC31",
-                "BMC31" : "BDI1_BMC31",
-                "AI"    : "AI"
+                "LUT": "ALUT",
+                "BDI1": "BDI1_BMC31",
+                "BMC31": "BDI1_BMC31",
+                "AI": "AI"
             },
         }
 
@@ -503,8 +502,8 @@ class XC7FasmGenerator(FasmGenerator):
                     continue
                 feature = (tile_name, slice_prefix, bel, pin)
             elif bel in slicem_srl_mux.keys():
-                feature = (tile_name, slice_prefix,
-                    slicem_srl_mux[bel]['LUT'], "DI1MUX", slicem_srl_mux[bel][pin])
+                feature = (tile_name, slice_prefix, slicem_srl_mux[bel]['LUT'],
+                           "DI1MUX", slicem_srl_mux[bel][pin])
             elif bel == "WEMUX":
                 if pin == "CE":
                     feature = (tile_name, slice_prefix, bel, pin)
@@ -606,6 +605,13 @@ class XC7FasmGenerator(FasmGenerator):
                 if prefix is None:
                     continue
 
+                io_re = re.compile(".*?X[0-9]+Y([0-9]+)")
+                m = io_re.match(tile)
+                y_coord = int(m.group(1))
+                if "SING" in tile and y_coord % 50 == 0:
+                    prefix = prefix[0:-1] + "0"
+                elif "SING" in tile and y_coord % 50 == 49:
+                    prefix = prefix[0:-1] + "1"
                 for feature in site_thru_feature.features:
                     self.add_cell_feature((tile, prefix, feature))
 


### PR DESCRIPTION
This PR fixes routing issues inside SLICEM sites, SRL muxes and some other signals related to distributed memory weren't properly handled. Also IO SING tiles had issue. These tiles only have 1 site, and its bits depend on tile position in the fabric grid.
For tiles that their Y mod 50 is zero, site uses bits for site Y0 but if Y mod 50 is 49 then site is configured using Y1 bits.
https://github.com/SymbiFlow/prjxray/blob/cb5f2a30633bf0d3ac91a9b5802790ac1da86736/fuzzers/005-tilegrid/generate_full.py#L357-L365