### PR TITLE
params: add other valid boolean strings when converting str to int

### DIFF
--- a/fpga_interchange/parameter_definitions.py
+++ b/fpga_interchange/parameter_definitions.py
@@ -227,9 +227,9 @@ class ParameterDefinition():
         assert self.is_integer_like(), (self.name, self.string_format)
 
         if self.string_format == ParameterFormat.BOOLEAN:
-            if str_value == "FALSE":
+            if str_value in ["FALSE", "0", "1'b0"]:
                 return 0
-            elif str_value == "TRUE":
+            elif str_value in ["TRUE", "1", "1'b1"]:
                 return 1
             else:
                 raise ValueError(


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

Possibly related to https://github.com/Xilinx/RapidWright/issues/216, some booleans can potentially be stored in different formats.

This PR is to allow having different version of the Boolean string format, so to decode the integer correctly.