### PR TITLE
Turn off pseudoPIPs going through LUT6 bels in Xilinx 7-series

### DIFF
--- a/test_data/series7_device_config.yaml
+++ b/test_data/series7_device_config.yaml
@@ -77,6 +77,10 @@ buckets:
 disabled_routethroughs:
   - BUFGCTRL
   - BUFR
+  - A6LUT
+  - B6LUT
+  - C6LUT
+  - D6LUT
 # Do not allow cells to be placed at BELs
 disabled_cell_bel_map:
   - cell: FDRE


### PR DESCRIPTION
Signed-off-by: Maciej Dudek <mdudek@antmicro.com>