### PR TITLE
Add LUT+FF clustering rule

### DIFF
--- a/test_data/series7_device_config.yaml
+++ b/test_data/series7_device_config.yaml
@@ -146,6 +146,22 @@ clusters:
       ports:
         - DATAOUT
 
+- name: LUTFF
+  root_cell_types:
+    - FDCE
+    - FDPE
+    - FDRE
+    - FDSE
+  cluster_cells:
+    - cells:
+      - LUT1
+      - LUT2
+      - LUT3
+      - LUT4
+      - LUT5
+      - LUT6
+      ports:
+      - D
 macro_clusters:
 - name: LUT6_2
   sites:

--- a/test_data/xcup_device_config.yaml
+++ b/test_data/xcup_device_config.yaml
@@ -145,6 +145,24 @@ disabled_site_pips:
     ipin: A6
     opin: O6
 
+clusters:
+- name: LUTFF
+  root_cell_types:
+    - FDCE
+    - FDPE
+    - FDRE
+    - FDSE
+  cluster_cells:
+    - cells:
+      - LUT1
+      - LUT2
+      - LUT3
+      - LUT4
+      - LUT5
+      - LUT6
+      ports:
+      - D
+
 macro_clusters:
 - name: RAM32X1S
   sites:


### PR DESCRIPTION
This PR adds additional clustering rules for `xc7` and `xcup` devices. The rules allow nextpnr to pack together LUTs and flip-flops which leads to SA placer runtime reduction.